### PR TITLE
feat: Dogecoin specific address type

### DIFF
--- a/bitcoin/src/dogecoin/address/error.rs
+++ b/bitcoin/src/dogecoin/address/error.rs
@@ -1,0 +1,110 @@
+//! Error code for the address module.
+
+use core::fmt;
+
+use internals::write_err;
+
+use crate::dogecoin::address::{Address, NetworkUnchecked};
+use crate::dogecoin::Network;
+
+pub use crate::address::error::{
+    FromScriptError, InvalidBase58PayloadLengthError, InvalidLegacyPrefixError,
+    LegacyAddressTooLongError, P2shError,
+};
+
+/// Address parsing error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ParseError {
+    /// Base58 error.
+    Base58(base58::Error),
+    /// Tried to parse an unknown HRP.
+    LegacyAddressTooLong(LegacyAddressTooLongError),
+    /// Invalid base58 payload data length for legacy address.
+    InvalidBase58PayloadLength(InvalidBase58PayloadLengthError),
+    /// Invalid legacy address prefix in base58 data payload.
+    InvalidLegacyPrefix(InvalidLegacyPrefixError),
+    /// Address's network differs from required one.
+    NetworkValidation(NetworkValidationError),
+}
+
+internals::impl_from_infallible!(ParseError);
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use ParseError::*;
+
+        match *self {
+            Base58(ref e) => write_err!(f, "base58 error"; e),
+            LegacyAddressTooLong(ref e) => write_err!(f, "legacy address base58 string"; e),
+            InvalidBase58PayloadLength(ref e) => write_err!(f, "legacy address base58 data"; e),
+            InvalidLegacyPrefix(ref e) => write_err!(f, "legacy address base58 prefix"; e),
+            NetworkValidation(ref e) => write_err!(f, "validation error"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ParseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use ParseError::*;
+
+        match *self {
+            Base58(ref e) => Some(e),
+            LegacyAddressTooLong(ref e) => Some(e),
+            InvalidBase58PayloadLength(ref e) => Some(e),
+            InvalidLegacyPrefix(ref e) => Some(e),
+            NetworkValidation(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<base58::Error> for ParseError {
+    fn from(e: base58::Error) -> Self {
+        Self::Base58(e)
+    }
+}
+
+impl From<LegacyAddressTooLongError> for ParseError {
+    fn from(e: LegacyAddressTooLongError) -> Self {
+        Self::LegacyAddressTooLong(e)
+    }
+}
+
+impl From<InvalidBase58PayloadLengthError> for ParseError {
+    fn from(e: InvalidBase58PayloadLengthError) -> Self {
+        Self::InvalidBase58PayloadLength(e)
+    }
+}
+
+impl From<InvalidLegacyPrefixError> for ParseError {
+    fn from(e: InvalidLegacyPrefixError) -> Self {
+        Self::InvalidLegacyPrefix(e)
+    }
+}
+
+impl From<NetworkValidationError> for ParseError {
+    fn from(e: NetworkValidationError) -> Self {
+        Self::NetworkValidation(e)
+    }
+}
+
+/// Address's network differs from required one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NetworkValidationError {
+    /// Network that was required.
+    pub(crate) required: Network,
+    /// The address itself.
+    pub(crate) address: Address<NetworkUnchecked>,
+}
+
+impl fmt::Display for NetworkValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "address ")?;
+        fmt::Display::fmt(&self.address.0, f)?;
+        write!(f, " is not valid on {}", self.required)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for NetworkValidationError {}

--- a/bitcoin/src/dogecoin/address/error.rs
+++ b/bitcoin/src/dogecoin/address/error.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! Error code for the address module.
 
 use core::fmt;
@@ -18,7 +20,7 @@ pub use crate::address::error::{
 pub enum ParseError {
     /// Base58 error.
     Base58(base58::Error),
-    /// Tried to parse an unknown HRP.
+    /// Legacy address is too long.
     LegacyAddressTooLong(LegacyAddressTooLongError),
     /// Invalid base58 payload data length for legacy address.
     InvalidBase58PayloadLength(InvalidBase58PayloadLengthError),

--- a/bitcoin/src/dogecoin/address/mod.rs
+++ b/bitcoin/src/dogecoin/address/mod.rs
@@ -8,8 +8,8 @@
 //!
 //! ```rust
 //! # #[cfg(feature = "rand-std")] {
-//! use bitcoin::dogecoin::{Address, PublicKey, Network};
-//! use bitcoin::secp256k1::{rand, Secp256k1};
+//! use bitcoin::dogecoin::{Address, Network};
+//! use bitcoin::{PublicKey, secp256k1::{rand, Secp256k1}};
 //!
 //! // Generate random key pair.
 //! let s = Secp256k1::new();

--- a/bitcoin/src/dogecoin/address/mod.rs
+++ b/bitcoin/src/dogecoin/address/mod.rs
@@ -1,0 +1,834 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Dogecoin addresses.
+//!
+//! Support for ordinary base58 Dogecoin addresses and private keys.
+//!
+//! # Example: creating a new address from a randomly-generated key pair
+//!
+//! ```rust
+//! # #[cfg(feature = "rand-std")] {
+//! use bitcoin::dogecoin::{Address, PublicKey, Network};
+//! use bitcoin::secp256k1::{rand, Secp256k1};
+//!
+//! // Generate random key pair.
+//! let s = Secp256k1::new();
+//! let public_key = PublicKey::new(s.generate_keypair(&mut rand::thread_rng()).1);
+//!
+//! // Generate pay-to-pubkey-hash address.
+//! let address = Address::p2pkh(&public_key, Network::Dogecoin);
+//! # }
+//! ```
+//!
+//! # Note: creating a new address requires the rand-std feature flag
+//!
+//! ```toml
+//! bitcoin = { version = "...", features = ["rand-std"] }
+//! ```
+
+pub mod error;
+
+use core::fmt;
+use core::marker::PhantomData;
+use core::str::FromStr;
+
+use hashes::{sha256, Hash, HashEngine};
+use secp256k1::XOnlyPublicKey;
+
+use crate::blockdata::constants::MAX_SCRIPT_ELEMENT_SIZE;
+use crate::blockdata::script::{self, Script, ScriptBuf, ScriptHash};
+use crate::crypto::key::{CompressedPublicKey, PubkeyHash, PublicKey};
+use crate::dogecoin::constants::{
+    PUBKEY_ADDRESS_PREFIX_MAINNET, PUBKEY_ADDRESS_PREFIX_REGTEST, PUBKEY_ADDRESS_PREFIX_TESTNET,
+    SCRIPT_ADDRESS_PREFIX_MAINNET, SCRIPT_ADDRESS_PREFIX_REGTEST, SCRIPT_ADDRESS_PREFIX_TESTNET,
+};
+use crate::dogecoin::Network;
+use crate::prelude::*;
+
+#[rustfmt::skip]                // Keep public re-exports separate.
+#[doc(inline)]
+pub use self::{
+    error::{
+        FromScriptError, InvalidBase58PayloadLengthError, InvalidLegacyPrefixError, LegacyAddressTooLongError,
+        NetworkValidationError, ParseError, P2shError,
+    },
+};
+
+// Re-export shared types from bitcoin::address.
+pub use crate::address::{AddressType, NetworkChecked, NetworkUnchecked, NetworkValidation};
+
+/// The inner representation of an address, without the network validation tag.
+///
+/// This struct represents the inner representation of an address without the network validation
+/// tag, which is used to ensure that addresses are used only on the appropriate network.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum AddressInner {
+    P2pkh { hash: PubkeyHash, network: Network },
+    P2sh { hash: ScriptHash, network: Network },
+}
+
+/// Formats bech32 as upper case if alternate formatting is chosen (`{:#}`).
+impl fmt::Display for AddressInner {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        use AddressInner::*;
+        match self {
+            P2pkh { hash, network } => {
+                let mut prefixed = [0; 21];
+                prefixed[0] = match network {
+                    Network::Dogecoin => PUBKEY_ADDRESS_PREFIX_MAINNET,
+                    Network::Testnet => PUBKEY_ADDRESS_PREFIX_TESTNET,
+                    Network::Regtest => PUBKEY_ADDRESS_PREFIX_REGTEST,
+                };
+                prefixed[1..].copy_from_slice(&hash[..]);
+                base58::encode_check_to_fmt(fmt, &prefixed[..])
+            }
+            P2sh { hash, network } => {
+                let mut prefixed = [0; 21];
+                prefixed[0] = match network {
+                    Network::Dogecoin => SCRIPT_ADDRESS_PREFIX_MAINNET,
+                    Network::Testnet => SCRIPT_ADDRESS_PREFIX_TESTNET,
+                    Network::Regtest => SCRIPT_ADDRESS_PREFIX_REGTEST,
+                };
+                prefixed[1..].copy_from_slice(&hash[..]);
+                base58::encode_check_to_fmt(fmt, &prefixed[..])
+            }
+        }
+    }
+}
+
+/// The data encoded by an `Address`.
+///
+/// This is the data used to encumber an output that pays to this address i.e., it is the address
+/// excluding the network information.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
+pub enum AddressData {
+    /// Data encoded by a P2PKH address.
+    P2pkh {
+        /// The pubkey hash used to encumber outputs to this address.
+        pubkey_hash: PubkeyHash,
+    },
+    /// Data encoded by a P2SH address.
+    P2sh {
+        /// The script hash used to encumber outputs to this address.
+        script_hash: ScriptHash,
+    },
+}
+
+/// A Dogecion address.
+///
+/// ### Parsing addresses
+///
+/// When parsing string as an address, one has to pay attention to the network, on which the parsed
+/// address is supposed to be valid. For the purpose of this validation, `Address` has
+/// [`is_valid_for_network`](Address<NetworkUnchecked>::is_valid_for_network) method. In order to provide more safety,
+/// enforced by compiler, `Address` also contains a special marker type, which indicates whether network of the parsed
+/// address has been checked. This marker type will prevent from calling certain functions unless the network
+/// verification has been successfully completed.
+///
+/// The result of parsing an address is `Address<NetworkUnchecked>` suggesting that network of the parsed address
+/// has not yet been verified. To perform this verification, method [`require_network`](Address<NetworkUnchecked>::require_network)
+/// can be called, providing network on which the address is supposed to be valid. If the verification succeeds,
+/// `Address<NetworkChecked>` is returned.
+///
+/// The types `Address` and `Address<NetworkChecked>` are synonymous, i. e. they can be used interchangeably.
+///
+/// ```rust
+/// use std::str::FromStr;
+/// use bitcoin::dogecoin::{Address, Network};
+/// use bitcoin::address::{NetworkUnchecked, NetworkChecked};
+///
+/// // variant 1
+/// let address: Address<NetworkUnchecked> = "DUSamFaUtRQ78DVidoeY3J8keYkQXdinrt".parse().unwrap();
+/// let address: Address<NetworkChecked> = address.require_network(Network::Dogecoin).unwrap();
+///
+/// // variant 2
+/// let address: Address = Address::from_str("DUSamFaUtRQ78DVidoeY3J8keYkQXdinrt").unwrap()
+///                .require_network(Network::Dogecoin).unwrap();
+///
+/// // variant 3
+/// let address: Address<NetworkChecked> = "DUSamFaUtRQ78DVidoeY3J8keYkQXdinrt".parse::<Address<_>>()
+///                .unwrap().require_network(Network::Dogecoin).unwrap();
+/// ```
+///
+/// ### Formatting addresses
+///
+/// To format address into its textual representation, both `Debug` (for usage in programmer-facing,
+/// debugging context) and `Display` (for user-facing output) can be used, with the following caveats:
+///
+/// 1. `Display` is implemented only for `Address<NetworkChecked>`:
+///
+/// ```
+/// # use std::str::FromStr;
+/// # use bitcoin::dogecoin::address::{Address, NetworkChecked};
+/// let address: Address<NetworkChecked> = Address::from_str("n48pquU8ieq7gidgJJ4vWD2jbsErmZvrwe")
+///                .unwrap().assume_checked();
+/// assert_eq!(address.to_string(), "n48pquU8ieq7gidgJJ4vWD2jbsErmZvrwe");
+/// ```
+///
+/// ```ignore
+/// # use std::str::FromStr;
+/// # use bitcoin::dogecoin::address::{Address, NetworkChecked};
+/// let address: Address<NetworkUnchecked> = Address::from_str("n48pquU8ieq7gidgJJ4vWD2jbsErmZvrwe")
+///                .unwrap();
+/// let s = address.to_string(); // does not compile
+/// ```
+///
+/// 2. `Debug` on `Address<NetworkUnchecked>` does not produce clean address but address wrapped by
+///    an indicator that its network has not been checked. This is to encourage programmer to properly
+///    check the network and use `Display` in user-facing context.
+///
+/// ```
+/// # use std::str::FromStr;
+/// # use bitcoin::address::{Address, NetworkUnchecked};
+/// let address: Address<NetworkUnchecked> = Address::from_str("n48pquU8ieq7gidgJJ4vWD2jbsErmZvrwe")
+///                .unwrap();
+/// assert_eq!(format!("{:?}", address), "Address<NetworkUnchecked>(n48pquU8ieq7gidgJJ4vWD2jbsErmZvrwe)");
+/// ```
+///
+/// ```
+/// # use std::str::FromStr;
+/// # use bitcoin::address::{Address, NetworkChecked};
+/// let address: Address<NetworkChecked> = Address::from_str("n48pquU8ieq7gidgJJ4vWD2jbsErmZvrwe")
+///                .unwrap().assume_checked();
+/// assert_eq!(format!("{:?}", address), "n48pquU8ieq7gidgJJ4vWD2jbsErmZvrwe");
+/// ```
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// The `#[repr(transparent)]` attribute is used to guarantee the layout of the `Address` struct. It
+// is an implementation detail and users should not rely on it in their code.
+#[repr(transparent)]
+pub struct Address<V = NetworkChecked>(AddressInner, PhantomData<V>)
+where
+    V: NetworkValidation;
+
+#[cfg(feature = "serde")]
+struct DisplayUnchecked<'a, N: NetworkValidation>(&'a Address<N>);
+
+#[cfg(feature = "serde")]
+impl<N: NetworkValidation> fmt::Display for DisplayUnchecked<'_, N> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.0 .0, fmt)
+    }
+}
+
+#[cfg(feature = "serde")]
+crate::serde_utils::serde_string_deserialize_impl!(Address<NetworkUnchecked>, "a Dogecoin address");
+
+#[cfg(feature = "serde")]
+impl<N: NetworkValidation> serde::Serialize for Address<N> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(&DisplayUnchecked(self))
+    }
+}
+
+/// Methods on [`Address`] that can be called on both `Address<NetworkChecked>` and
+/// `Address<NetworkUnchecked>`.
+impl<V: NetworkValidation> Address<V> {
+    /// Returns a reference to the address as if it was unchecked.
+    pub fn as_unchecked(&self) -> &Address<NetworkUnchecked> {
+        unsafe { &*(self as *const Address<V> as *const Address<NetworkUnchecked>) }
+    }
+
+    /// Marks the network of this address as unchecked.
+    pub fn into_unchecked(self) -> Address<NetworkUnchecked> {
+        Address(self.0, PhantomData)
+    }
+}
+
+/// Methods and functions that can be called only on `Address<NetworkChecked>`.
+impl Address {
+    /// Creates a pay to (compressed) public key hash address from a public key.
+    ///
+    /// This is the preferred non-witness type address.
+    #[inline]
+    pub fn p2pkh(pk: impl Into<PubkeyHash>, network: impl Into<Network>) -> Address {
+        let hash = pk.into();
+        Self(AddressInner::P2pkh { hash, network: network.into() }, PhantomData)
+    }
+
+    /// Creates a pay to script hash P2SH address from a script.
+    ///
+    /// This address type was introduced with BIP16 and is the popular type to implement multi-sig
+    /// these days.
+    #[inline]
+    pub fn p2sh(script: &Script, network: impl Into<Network>) -> Result<Address, P2shError> {
+        if script.len() > MAX_SCRIPT_ELEMENT_SIZE {
+            return Err(P2shError::ExcessiveScriptSize);
+        }
+        let hash = script.script_hash();
+        Ok(Address::p2sh_from_hash(hash, network))
+    }
+
+    /// Creates a pay to script hash P2SH address from a script hash.
+    ///
+    /// # Warning
+    ///
+    /// The `hash` pre-image (redeem script) must not exceed 520 bytes in length
+    /// otherwise outputs created from the returned address will be un-spendable.
+    pub fn p2sh_from_hash(hash: ScriptHash, network: impl Into<Network>) -> Address {
+        Self(AddressInner::P2sh { hash, network: network.into() }, PhantomData)
+    }
+
+    /// Creates a pay to script address that embeds a witness pay to public key.
+    ///
+    /// This is a segwit address type that looks familiar (as p2sh) to legacy clients.
+    pub fn p2shwpkh(pk: &CompressedPublicKey, network: impl Into<Network>) -> Address {
+        let builder = script::Builder::new().push_int(0).push_slice(pk.wpubkey_hash());
+        let script_hash = builder.as_script().script_hash();
+        Address::p2sh_from_hash(script_hash, network)
+    }
+
+    /// Creates a pay to script address that embeds a witness pay to script hash address.
+    ///
+    /// This is a segwit address type that looks familiar (as p2sh) to legacy clients.
+    pub fn p2shwsh(script: &Script, network: impl Into<Network>) -> Address {
+        let builder = script::Builder::new().push_int(0).push_slice(script.wscript_hash());
+        let script_hash = builder.as_script().script_hash();
+        Address::p2sh_from_hash(script_hash, network)
+    }
+
+    /// Gets the address type of the address.
+    ///
+    /// # Returns
+    ///
+    /// None if unknown, non-standard or related to the future witness version.
+    #[inline]
+    pub fn address_type(&self) -> Option<AddressType> {
+        match self.0 {
+            AddressInner::P2pkh { .. } => Some(AddressType::P2pkh),
+            AddressInner::P2sh { .. } => Some(AddressType::P2sh),
+        }
+    }
+
+    /// Gets the address data from this address.
+    pub fn to_address_data(&self) -> AddressData {
+        use AddressData::*;
+
+        match self.0 {
+            AddressInner::P2pkh { hash, network: _ } => P2pkh { pubkey_hash: hash },
+            AddressInner::P2sh { hash, network: _ } => P2sh { script_hash: hash },
+        }
+    }
+
+    /// Gets the pubkey hash for this address if this is a P2PKH address.
+    pub fn pubkey_hash(&self) -> Option<PubkeyHash> {
+        use AddressInner::*;
+
+        match self.0 {
+            P2pkh { ref hash, network: _ } => Some(*hash),
+            _ => None,
+        }
+    }
+
+    /// Gets the script hash for this address if this is a P2SH address.
+    pub fn script_hash(&self) -> Option<ScriptHash> {
+        use AddressInner::*;
+
+        match self.0 {
+            P2sh { ref hash, network: _ } => Some(*hash),
+            _ => None,
+        }
+    }
+
+    /// Checks whether or not the address is following Dogecoin standardness rules when
+    /// *spending* from this address. *NOT* to be called by senders.
+    ///
+    /// <details>
+    /// <summary>Spending Standardness</summary>
+    ///
+    /// For forward compatibility, the senders must send to any [`Address`]. Receivers
+    /// can use this method to check whether or not they can spend from this address.
+    ///
+    /// SegWit addresses with unassigned witness versions or non-standard program sizes are
+    /// considered non-standard.
+    /// </details>
+    ///
+    pub fn is_spend_standard(&self) -> bool {
+        self.address_type().is_some()
+    }
+
+    /// Constructs an [`Address`] from an output script (`scriptPubkey`).
+    pub fn from_script(
+        script: &Script,
+        network: impl Into<Network>,
+    ) -> Result<Address, FromScriptError> {
+        let network = network.into();
+        if script.is_p2pkh() {
+            let bytes = script.as_bytes()[3..23].try_into().expect("statically 20B long");
+            let hash = PubkeyHash::from_byte_array(bytes);
+            Ok(Address::p2pkh(hash, network))
+        } else if script.is_p2sh() {
+            let bytes = script.as_bytes()[2..22].try_into().expect("statically 20B long");
+            let hash = ScriptHash::from_byte_array(bytes);
+            Ok(Address::p2sh_from_hash(hash, network))
+        } else {
+            Err(FromScriptError::UnrecognizedScript)
+        }
+    }
+
+    /// Generates a script pubkey spending to this address.
+    pub fn script_pubkey(&self) -> ScriptBuf {
+        use AddressInner::*;
+        match self.0 {
+            P2pkh { ref hash, network: _ } => ScriptBuf::new_p2pkh(hash),
+            P2sh { ref hash, network: _ } => ScriptBuf::new_p2sh(hash),
+        }
+    }
+
+    /// Creates a URI string *bitcoin:address* optimized to be encoded in QR codes.
+    pub fn to_qr_uri(&self) -> String {
+        format!("bitcoin:{:#}", self)
+    }
+
+    /// Returns true if the given pubkey is directly related to the address payload.
+    ///
+    /// This is determined by directly comparing the address payload with either the
+    /// hash of the given public key or the segwit redeem hash generated from the
+    /// given key. For taproot addresses, the supplied key is assumed to be tweaked
+    pub fn is_related_to_pubkey(&self, pubkey: &PublicKey) -> bool {
+        let pubkey_hash = pubkey.pubkey_hash();
+        let payload = self.payload_as_bytes();
+        let xonly_pubkey = XOnlyPublicKey::from(pubkey.inner);
+
+        (*pubkey_hash.as_byte_array() == *payload)
+            || (xonly_pubkey.serialize() == *payload)
+            || (*segwit_redeem_hash(&pubkey_hash).as_byte_array() == *payload)
+    }
+
+    /// Returns true if the supplied xonly public key can be used to derive the address.
+    ///
+    /// This will only work for Taproot addresses. The Public Key is
+    /// assumed to have already been tweaked.
+    pub fn is_related_to_xonly_pubkey(&self, xonly_pubkey: &XOnlyPublicKey) -> bool {
+        xonly_pubkey.serialize() == *self.payload_as_bytes()
+    }
+
+    /// Returns true if the address creates a particular script
+    /// This function doesn't make any allocations.
+    pub fn matches_script_pubkey(&self, script: &Script) -> bool {
+        use AddressInner::*;
+        match self.0 {
+            P2pkh { ref hash, network: _ } if script.is_p2pkh() => {
+                &script.as_bytes()[3..23] == <PubkeyHash as AsRef<[u8; 20]>>::as_ref(hash)
+            }
+            P2sh { ref hash, network: _ } if script.is_p2sh() => {
+                &script.as_bytes()[2..22] == <ScriptHash as AsRef<[u8; 20]>>::as_ref(hash)
+            }
+            P2pkh { .. } | P2sh { .. } => false,
+        }
+    }
+
+    /// Returns the "payload" for this address.
+    ///
+    /// The "payload" is the useful stuff excluding serialization prefix, the exact payload is
+    /// dependent on the inner address:
+    ///
+    /// - For p2sh, the payload is the script hash.
+    /// - For p2pkh, the payload is the pubkey hash.
+    /// - For segwit addresses, the payload is the witness program.
+    fn payload_as_bytes(&self) -> &[u8] {
+        use AddressInner::*;
+        match self.0 {
+            P2sh { ref hash, network: _ } => hash.as_ref(),
+            P2pkh { ref hash, network: _ } => hash.as_ref(),
+        }
+    }
+}
+
+/// Methods that can be called only on `Address<NetworkUnchecked>`.
+impl Address<NetworkUnchecked> {
+    /// Returns a reference to the checked address.
+    ///
+    /// This function is dangerous in case the address is not a valid checked address.
+    pub fn assume_checked_ref(&self) -> &Address {
+        unsafe { &*(self as *const Address<NetworkUnchecked> as *const Address) }
+    }
+
+    /// Parsed addresses do not always have *one* network. The problem is that testnet,
+    /// regtest p2pkh addresses use different prefixes, but testnet and regtest p2sh
+    /// addresses use the same prefix.
+    ///
+    /// So if one wants to check if an address belongs to a certain network a simple
+    /// comparison is not enough anymore. Instead this function can be used.
+    ///
+    /// ```rust
+    /// use bitcoin::dogecoin::{Address, Network};
+    /// use bitcoin::address::NetworkUnchecked;
+    ///
+    /// let address: Address<NetworkUnchecked> = "no2dRNaFqxNjWZLeTRu4XyCuzeGdE3VY2S".parse().unwrap();
+    /// assert!(address.is_valid_for_network(Network::Testnet));
+    /// assert_eq!(address.is_valid_for_network(Network::Regtest), false);
+    ///
+    /// let address: Address<NetworkUnchecked> = "n48pquU8ieq7gidgJJ4vWD2jbsErmZvrwe".parse().unwrap();
+    /// assert!(address.is_valid_for_network(Network::Regtest));
+    /// assert_eq!(address.is_valid_for_network(Network::Testnet), false);
+    ///
+    /// let address: Address<NetworkUnchecked> = "DUSamFaUtRQ78DVidoeY3J8keYkQXdinrt".parse().unwrap();
+    /// assert!(address.is_valid_for_network(Network::Dogecoin));
+    /// assert_eq!(address.is_valid_for_network(Network::Testnet), false);
+    ///
+    /// let address: Address<NetworkUnchecked> = "2N3zXjbwdTcPsJiy8sUK9FhWJhqQCxA8Jjr".parse().unwrap();
+    /// assert!(address.is_valid_for_network(Network::Testnet));
+    /// assert!(address.is_valid_for_network(Network::Regtest));
+    /// assert_eq!(address.is_valid_for_network(Network::Dogecoin), false);
+    /// ```
+    pub fn is_valid_for_network(&self, n: Network) -> bool {
+        use AddressInner::*;
+        match self.0 {
+            P2pkh { hash: _, ref network } => *network == n,
+            P2sh { hash: _, network: Network::Dogecoin } => n == Network::Dogecoin,
+            P2sh { hash: _, network: Network::Testnet } => {
+                n == Network::Testnet || n == Network::Regtest
+            }
+            P2sh { hash: _, network: Network::Regtest } => {
+                n == Network::Testnet || n == Network::Regtest
+            }
+        }
+    }
+
+    /// Checks whether network of this address is as required.
+    ///
+    /// For details about this mechanism, see section [*Parsing addresses*](Address#parsing-addresses)
+    /// on [`Address`].
+    ///
+    /// # Errors
+    ///
+    /// This function only ever returns the [`ParseError::NetworkValidation`] variant of
+    /// `ParseError`. This is not how we normally implement errors in this library but
+    /// `require_network` is not a typical function, it is conceptually part of string parsing.
+    ///
+    ///  # Examples
+    ///
+    /// ```
+    /// use bitcoin::address::{NetworkChecked, NetworkUnchecked};
+    /// use bitcoin::dogecoin::{Address, Network, ParseError};
+    ///
+    /// const ADDR: &str = "DUSamFaUtRQ78DVidoeY3J8keYkQXdinrt";
+    ///
+    /// fn parse_and_validate_address(network: Network) -> Result<Address, ParseError> {
+    ///     let address = ADDR.parse::<Address<_>>()?
+    ///                       .require_network(network)?;
+    ///     Ok(address)
+    /// }
+    ///
+    /// fn parse_and_validate_address_combinator(network: Network) -> Result<Address, ParseError> {
+    ///     let address = ADDR.parse::<Address<_>>()
+    ///                       .and_then(|a| a.require_network(network))?;
+    ///     Ok(address)
+    /// }
+    ///
+    /// fn parse_and_validate_address_show_types(network: Network) -> Result<Address, ParseError> {
+    ///     let address: Address<NetworkChecked> = ADDR.parse::<Address<NetworkUnchecked>>()?
+    ///                                                .require_network(network)?;
+    ///     Ok(address)
+    /// }
+    ///
+    /// let network = Network::Dogecoin;  // Don't hard code network in applications.
+    /// let _ = parse_and_validate_address(network).unwrap();
+    /// let _ = parse_and_validate_address_combinator(network).unwrap();
+    /// let _ = parse_and_validate_address_show_types(network).unwrap();
+    /// ```
+    #[inline]
+    pub fn require_network(self, required: Network) -> Result<Address, ParseError> {
+        if self.is_valid_for_network(required) {
+            Ok(self.assume_checked())
+        } else {
+            Err(NetworkValidationError { required, address: self }.into())
+        }
+    }
+
+    /// Marks, without any additional checks, network of this address as checked.
+    ///
+    /// Improper use of this method may lead to loss of funds. Reader will most likely prefer
+    /// [`require_network`](Address<NetworkUnchecked>::require_network) as a safe variant.
+    /// For details about this mechanism, see section [*Parsing addresses*](Address#parsing-addresses)
+    /// on [`Address`].
+    #[inline]
+    pub fn assume_checked(self) -> Address {
+        Address(self.0, PhantomData)
+    }
+}
+
+impl From<Address> for script::ScriptBuf {
+    fn from(a: Address) -> Self {
+        a.script_pubkey()
+    }
+}
+
+// Alternate formatting `{:#}` is used to return uppercase version of bech32 addresses which should
+// be used in QR codes, see [`Address::to_qr_uri`].
+impl fmt::Display for Address {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.0, fmt)
+    }
+}
+
+impl<V: NetworkValidation> fmt::Debug for Address<V> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if V::IS_CHECKED {
+            fmt::Display::fmt(&self.0, f)
+        } else {
+            write!(f, "Address<NetworkUnchecked>(")?;
+            fmt::Display::fmt(&self.0, f)?;
+            write!(f, ")")
+        }
+    }
+}
+
+/// Address can be parsed only with `NetworkUnchecked`.
+impl FromStr for Address<NetworkUnchecked> {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Address<NetworkUnchecked>, ParseError> {
+        if s.len() > 50 {
+            return Err(LegacyAddressTooLongError { length: s.len() }.into());
+        }
+        let data = base58::decode_check(s)?;
+        if data.len() != 21 {
+            return Err(InvalidBase58PayloadLengthError { length: s.len() }.into());
+        }
+
+        let (prefix, data) = data.split_first().expect("length checked above");
+        let data: [u8; 20] = data.try_into().expect("length checked above");
+
+        let inner = match *prefix {
+            PUBKEY_ADDRESS_PREFIX_MAINNET => {
+                let hash = PubkeyHash::from_byte_array(data);
+                AddressInner::P2pkh { hash, network: Network::Dogecoin }
+            }
+            PUBKEY_ADDRESS_PREFIX_TESTNET => {
+                let hash = PubkeyHash::from_byte_array(data);
+                AddressInner::P2pkh { hash, network: Network::Testnet }
+            }
+            PUBKEY_ADDRESS_PREFIX_REGTEST => {
+                let hash = PubkeyHash::from_byte_array(data);
+                AddressInner::P2pkh { hash, network: Network::Regtest }
+            }
+            SCRIPT_ADDRESS_PREFIX_MAINNET => {
+                let hash = ScriptHash::from_byte_array(data);
+                AddressInner::P2sh { hash, network: Network::Dogecoin }
+            }
+            SCRIPT_ADDRESS_PREFIX_TESTNET => {
+                let hash = ScriptHash::from_byte_array(data);
+                AddressInner::P2sh { hash, network: Network::Testnet }
+            }
+            invalid => return Err(InvalidLegacyPrefixError { invalid }.into()),
+        };
+
+        Ok(Address(inner, PhantomData))
+    }
+}
+
+/// Convert a byte array of a pubkey hash into a segwit redeem hash
+fn segwit_redeem_hash(pubkey_hash: &PubkeyHash) -> crate::hashes::hash160::Hash {
+    let mut sha_engine = sha256::Hash::engine();
+    sha_engine.input(&[0, 20]);
+    sha_engine.input(pubkey_hash.as_ref());
+    crate::hashes::hash160::Hash::from_engine(sha_engine)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dogecoin::Network::{Dogecoin, Testnet};
+
+    fn roundtrips(addr: &Address, network: Network) {
+        assert_eq!(
+            Address::from_str(&addr.to_string()).unwrap().assume_checked(),
+            *addr,
+            "string round-trip failed for {}",
+            addr,
+        );
+        assert_eq!(
+            Address::from_script(&addr.script_pubkey(), network)
+                .expect("failed to create inner address from script_pubkey"),
+            *addr,
+            "script round-trip failed for {}",
+            addr,
+        );
+
+        #[cfg(feature = "serde")]
+        {
+            let ser = serde_json::to_string(addr).expect("failed to serialize address");
+            let back: Address<NetworkUnchecked> =
+                serde_json::from_str(&ser).expect("failed to deserialize address");
+            assert_eq!(back.assume_checked(), *addr, "serde round-trip failed for {}", addr)
+        }
+    }
+
+    #[test]
+    fn test_p2pkh_address_58() {
+        let hash = "162c5ea71c0b23f5b9022ef047c4a86470a5b070".parse::<PubkeyHash>().unwrap();
+        let addr = Address::p2pkh(hash, Network::Dogecoin);
+
+        assert_eq!(
+            addr.script_pubkey(),
+            ScriptBuf::from_hex("76a914162c5ea71c0b23f5b9022ef047c4a86470a5b07088ac").unwrap()
+        );
+        assert_eq!(&addr.to_string(), "D7ALZLo7BL5vM9Vb4vAqvqwX9fpQ4wKRiy");
+        assert_eq!(addr.address_type(), Some(AddressType::P2pkh));
+        roundtrips(&addr, Dogecoin);
+    }
+
+    #[test]
+    fn test_p2pkh_from_key() {
+        let key = "048d5141948c1702e8c95f438815794b87f706a8d4cd2bffad1dc1570971032c9b6042a0431ded2478b5c9cf2d81c124a5e57347a3c63ef0e7716cf54d613ba183".parse::<PublicKey>().unwrap();
+        let addr = Address::p2pkh(key, Network::Dogecoin);
+        assert_eq!(&addr.to_string(), "DUSamFaUtRQ78DVidoeY3J8keYkQXdinrt");
+
+        let key = "03df154ebfcf29d29cc10d5c2565018bce2d9edbab267c31d2caf44a63056cf99f"
+            .parse::<PublicKey>()
+            .unwrap();
+        let addr = Address::p2pkh(key, Network::Testnet);
+        assert_eq!(&addr.to_string(), "neRuCZsfnZaJN8FmxxVZDSZbcGATnzGByf");
+        assert_eq!(addr.address_type(), Some(AddressType::P2pkh));
+        roundtrips(&addr, Testnet);
+    }
+
+    #[test]
+    fn test_p2sh_address_58() {
+        let hash = "162c5ea71c0b23f5b9022ef047c4a86470a5b070".parse::<ScriptHash>().unwrap();
+        let addr = Address::p2sh_from_hash(hash, Network::Dogecoin);
+
+        assert_eq!(
+            addr.script_pubkey(),
+            ScriptBuf::from_hex("a914162c5ea71c0b23f5b9022ef047c4a86470a5b07087").unwrap(),
+        );
+        assert_eq!(&addr.to_string(), "9tTWgUQoVtNuogNtsZWJ3qmE7dkrPTrVAj");
+        assert_eq!(addr.address_type(), Some(AddressType::P2sh));
+        roundtrips(&addr, Dogecoin);
+    }
+
+    #[test]
+    fn test_p2sh_parse() {
+        let script = ScriptBuf::from_hex("552103a765fc35b3f210b95223846b36ef62a4e53e34e2925270c2c7906b92c9f718eb2103c327511374246759ec8d0b89fa6c6b23b33e11f92c5bc155409d86de0c79180121038cae7406af1f12f4786d820a1466eec7bc5785a1b5e4a387eca6d797753ef6db2103252bfb9dcaab0cd00353f2ac328954d791270203d66c2be8b430f115f451b8a12103e79412d42372c55dd336f2eb6eb639ef9d74a22041ba79382c74da2338fe58ad21035049459a4ebc00e876a9eef02e72a3e70202d3d1f591fc0dd542f93f642021f82102016f682920d9723c61b27f562eb530c926c00106004798b6471e8c52c60ee02057ae").unwrap();
+        let addr = Address::p2sh(&script, Network::Testnet).unwrap();
+        assert_eq!(&addr.to_string(), "2N3zXjbwdTcPsJiy8sUK9FhWJhqQCxA8Jjr");
+        assert_eq!(addr.address_type(), Some(AddressType::P2sh));
+        roundtrips(&addr, Testnet);
+    }
+
+    #[test]
+    fn test_p2sh_parse_for_large_script() {
+        let script = ScriptBuf::from_hex("552103a765fc35b3f210b95223846b36ef62a4e53e34e2925270c2c7906b92c9f718eb2103c327511374246759ec8d0b89fa6c6b23b33e11f92c5bc155409d86de0c79180121038cae7406af1f12f4786d820a1466eec7bc5785a1b5e4a387eca6d797753ef6db2103252bfb9dcaab0cd00353f2ac328954d791270203d66c2be8b430f115f451b8a12103e79412d42372c55dd336f2eb6eb639ef9d74a22041ba79382c74da2338fe58ad21035049459a4ebc00e876a9eef02e72a3e70202d3d1f591fc0dd542f93f642021f82102016f682920d9723c61b27f562eb530c926c00106004798b6471e8c52c60ee02057ae12123122313123123ac1231231231231313123131231231231313212313213123123552103a765fc35b3f210b95223846b36ef62a4e53e34e2925270c2c7906b92c9f718eb2103c327511374246759ec8d0b89fa6c6b23b33e11f92c5bc155409d86de0c79180121038cae7406af1f12f4786d820a1466eec7bc5785a1b5e4a387eca6d797753ef6db2103252bfb9dcaab0cd00353f2ac328954d791270203d66c2be8b430f115f451b8a12103e79412d42372c55dd336f2eb6eb639ef9d74a22041ba79382c74da2338fe58ad21035049459a4ebc00e876a9eef02e72a3e70202d3d1f591fc0dd542f93f642021f82102016f682920d9723c61b27f562eb530c926c00106004798b6471e8c52c60ee02057ae12123122313123123ac1231231231231313123131231231231313212313213123123552103a765fc35b3f210b95223846b36ef62a4e53e34e2925270c2c7906b92c9f718eb2103c327511374246759ec8d0b89fa6c6b23b33e11f92c5bc155409d86de0c79180121038cae7406af1f12f4786d820a1466eec7bc5785a1b5e4a387eca6d797753ef6db2103252bfb9dcaab0cd00353f2ac328954d791270203d66c2be8b430f115f451b8a12103e79412d42372c55dd336f2eb6eb639ef9d74a22041ba79382c74da2338fe58ad21035049459a4ebc00e876a9eef02e72a3e70202d3d1f591fc0dd542f93f642021f82102016f682920d9723c61b27f562eb530c926c00106004798b6471e8c52c60ee02057ae12123122313123123ac1231231231231313123131231231231313212313213123123").unwrap();
+        assert_eq!(Address::p2sh(&script, Network::Testnet), Err(P2shError::ExcessiveScriptSize));
+    }
+
+    #[test]
+    fn test_address_debug() {
+        // This is not really testing output of Debug but the ability and proper functioning
+        // of Debug derivation on structs generic in NetworkValidation.
+        #[derive(Debug)]
+        #[allow(unused)]
+        struct Test<V: NetworkValidation> {
+            address: Address<V>,
+        }
+
+        let addr_str = "n48pquU8ieq7gidgJJ4vWD2jbsErmZvrwe";
+        let unchecked = Address::from_str(addr_str).unwrap();
+
+        assert_eq!(
+            format!("{:?}", Test { address: unchecked.clone() }),
+            format!("Test {{ address: Address<NetworkUnchecked>({}) }}", addr_str)
+        );
+
+        assert_eq!(
+            format!("{:?}", Test { address: unchecked.assume_checked() }),
+            format!("Test {{ address: {} }}", addr_str)
+        );
+    }
+
+    #[test]
+    fn test_address_type() {
+        let addresses = [
+            ("DMKhUaRmnxJXfDxyFguMnMjVdgvnNipFzt", Some(AddressType::P2pkh)),
+            ("A1yb6viUzAcUWftRHT6GpnCwvhXHg4CV1x", Some(AddressType::P2sh)),
+        ];
+        for (address, expected_type) in &addresses {
+            let addr = Address::from_str(address)
+                .unwrap()
+                .require_network(Network::Dogecoin)
+                .expect("mainnet");
+            assert_eq!(&addr.address_type(), expected_type);
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_json_serialize() {
+        use serde_json;
+
+        let addr =
+            Address::from_str("D7ALZLo7BL5vM9Vb4vAqvqwX9fpQ4wKRiy").unwrap().assume_checked();
+        let json = serde_json::to_value(&addr).unwrap();
+        assert_eq!(
+            json,
+            serde_json::Value::String("D7ALZLo7BL5vM9Vb4vAqvqwX9fpQ4wKRiy".to_owned())
+        );
+        let into: Address = serde_json::from_value::<Address<_>>(json).unwrap().assume_checked();
+        assert_eq!(addr.to_string(), into.to_string());
+        assert_eq!(
+            into.script_pubkey(),
+            ScriptBuf::from_hex("76a914162c5ea71c0b23f5b9022ef047c4a86470a5b07088ac").unwrap()
+        );
+
+        let addr =
+            Address::from_str("9tTWgUQoVtNuogNtsZWJ3qmE7dkrPTrVAj").unwrap().assume_checked();
+        let json = serde_json::to_value(&addr).unwrap();
+        assert_eq!(
+            json,
+            serde_json::Value::String("9tTWgUQoVtNuogNtsZWJ3qmE7dkrPTrVAj".to_owned())
+        );
+        let into: Address = serde_json::from_value::<Address<_>>(json).unwrap().assume_checked();
+        assert_eq!(addr.to_string(), into.to_string());
+        assert_eq!(
+            into.script_pubkey(),
+            ScriptBuf::from_hex("a914162c5ea71c0b23f5b9022ef047c4a86470a5b07087").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_is_related_to_pubkey_p2pkh() {
+        let address_string = "neRuCZsfnZaJN8FmxxVZDSZbcGATnzGByf";
+        let address = Address::from_str(address_string)
+            .expect("address")
+            .require_network(Network::Testnet)
+            .expect("testnet");
+
+        let pubkey_string = "03df154ebfcf29d29cc10d5c2565018bce2d9edbab267c31d2caf44a63056cf99f";
+        let pubkey = PublicKey::from_str(pubkey_string).expect("pubkey");
+
+        let result = address.is_related_to_pubkey(&pubkey);
+        assert!(result);
+
+        let unused_pubkey = PublicKey::from_str(
+            "02ba604e6ad9d3864eda8dc41c62668514ef7d5417d3b6db46e45cc4533bff001c",
+        )
+        .expect("pubkey");
+        assert!(!address.is_related_to_pubkey(&unused_pubkey))
+    }
+
+    #[test]
+    fn test_is_related_to_pubkey_p2pkh_uncompressed_key() {
+        let address_string = "DUSamFaUtRQ78DVidoeY3J8keYkQXdinrt";
+        let address = Address::from_str(address_string)
+            .expect("address")
+            .require_network(Network::Dogecoin)
+            .expect("mainnet");
+
+        let pubkey_string = "048d5141948c1702e8c95f438815794b87f706a8d4cd2bffad1dc1570971032c9b6042a0431ded2478b5c9cf2d81c124a5e57347a3c63ef0e7716cf54d613ba183";
+        let pubkey = PublicKey::from_str(pubkey_string).expect("pubkey");
+
+        let result = address.is_related_to_pubkey(&pubkey);
+        assert!(result);
+
+        let unused_pubkey = PublicKey::from_str(
+            "02ba604e6ad9d3864eda8dc41c62668514ef7d5417d3b6db46e45cc4533bff001c",
+        )
+        .expect("pubkey");
+        assert!(!address.is_related_to_pubkey(&unused_pubkey))
+    }
+}

--- a/bitcoin/src/dogecoin/address/mod.rs
+++ b/bitcoin/src/dogecoin/address/mod.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC0-1.0
+// SPDX-License-Identifier: Apache-2.0
 
 //! Dogecoin addresses.
 //!
@@ -32,12 +32,12 @@ use core::fmt;
 use core::marker::PhantomData;
 use core::str::FromStr;
 
-use hashes::{sha256, Hash, HashEngine};
+use hashes::Hash;
 use secp256k1::XOnlyPublicKey;
 
 use crate::blockdata::constants::MAX_SCRIPT_ELEMENT_SIZE;
 use crate::blockdata::script::{self, Script, ScriptBuf, ScriptHash};
-use crate::crypto::key::{CompressedPublicKey, PubkeyHash, PublicKey};
+use crate::crypto::key::{PubkeyHash, PublicKey};
 use crate::dogecoin::constants::{
     PUBKEY_ADDRESS_PREFIX_MAINNET, PUBKEY_ADDRESS_PREFIX_REGTEST, PUBKEY_ADDRESS_PREFIX_TESTNET,
     SCRIPT_ADDRESS_PREFIX_MAINNET, SCRIPT_ADDRESS_PREFIX_REGTEST, SCRIPT_ADDRESS_PREFIX_TESTNET,
@@ -114,7 +114,7 @@ pub enum AddressData {
     },
 }
 
-/// A Dogecion address.
+/// A Dogecoin address.
 ///
 /// ### Parsing addresses
 ///
@@ -179,7 +179,7 @@ pub enum AddressData {
 ///
 /// ```
 /// # use std::str::FromStr;
-/// # use bitcoin::address::{Address, NetworkUnchecked};
+/// # use bitcoin::dogecoin::address::{Address, NetworkUnchecked};
 /// let address: Address<NetworkUnchecked> = Address::from_str("n48pquU8ieq7gidgJJ4vWD2jbsErmZvrwe")
 ///                .unwrap();
 /// assert_eq!(format!("{:?}", address), "Address<NetworkUnchecked>(n48pquU8ieq7gidgJJ4vWD2jbsErmZvrwe)");
@@ -187,7 +187,7 @@ pub enum AddressData {
 ///
 /// ```
 /// # use std::str::FromStr;
-/// # use bitcoin::address::{Address, NetworkChecked};
+/// # use bitcoin::dogecoin::address::{Address, NetworkChecked};
 /// let address: Address<NetworkChecked> = Address::from_str("n48pquU8ieq7gidgJJ4vWD2jbsErmZvrwe")
 ///                .unwrap().assume_checked();
 /// assert_eq!(format!("{:?}", address), "n48pquU8ieq7gidgJJ4vWD2jbsErmZvrwe");
@@ -271,24 +271,6 @@ impl Address {
         Self(AddressInner::P2sh { hash, network: network.into() }, PhantomData)
     }
 
-    /// Creates a pay to script address that embeds a witness pay to public key.
-    ///
-    /// This is a segwit address type that looks familiar (as p2sh) to legacy clients.
-    pub fn p2shwpkh(pk: &CompressedPublicKey, network: impl Into<Network>) -> Address {
-        let builder = script::Builder::new().push_int(0).push_slice(pk.wpubkey_hash());
-        let script_hash = builder.as_script().script_hash();
-        Address::p2sh_from_hash(script_hash, network)
-    }
-
-    /// Creates a pay to script address that embeds a witness pay to script hash address.
-    ///
-    /// This is a segwit address type that looks familiar (as p2sh) to legacy clients.
-    pub fn p2shwsh(script: &Script, network: impl Into<Network>) -> Address {
-        let builder = script::Builder::new().push_int(0).push_slice(script.wscript_hash());
-        let script_hash = builder.as_script().script_hash();
-        Address::p2sh_from_hash(script_hash, network)
-    }
-
     /// Gets the address type of the address.
     ///
     /// # Returns
@@ -332,23 +314,6 @@ impl Address {
         }
     }
 
-    /// Checks whether or not the address is following Dogecoin standardness rules when
-    /// *spending* from this address. *NOT* to be called by senders.
-    ///
-    /// <details>
-    /// <summary>Spending Standardness</summary>
-    ///
-    /// For forward compatibility, the senders must send to any [`Address`]. Receivers
-    /// can use this method to check whether or not they can spend from this address.
-    ///
-    /// SegWit addresses with unassigned witness versions or non-standard program sizes are
-    /// considered non-standard.
-    /// </details>
-    ///
-    pub fn is_spend_standard(&self) -> bool {
-        self.address_type().is_some()
-    }
-
     /// Constructs an [`Address`] from an output script (`scriptPubkey`).
     pub fn from_script(
         script: &Script,
@@ -387,17 +352,7 @@ impl Address {
         let payload = self.payload_as_bytes();
         let xonly_pubkey = XOnlyPublicKey::from(pubkey.inner);
 
-        (*pubkey_hash.as_byte_array() == *payload)
-            || (xonly_pubkey.serialize() == *payload)
-            || (*segwit_redeem_hash(&pubkey_hash).as_byte_array() == *payload)
-    }
-
-    /// Returns true if the supplied xonly public key can be used to derive the address.
-    ///
-    /// This will only work for Taproot addresses. The Public Key is
-    /// assumed to have already been tweaked.
-    pub fn is_related_to_xonly_pubkey(&self, xonly_pubkey: &XOnlyPublicKey) -> bool {
-        xonly_pubkey.serialize() == *self.payload_as_bytes()
+        (*pubkey_hash.as_byte_array() == *payload) || (xonly_pubkey.serialize() == *payload)
     }
 
     /// Returns true if the address creates a particular script
@@ -422,7 +377,6 @@ impl Address {
     ///
     /// - For p2sh, the payload is the script hash.
     /// - For p2pkh, the payload is the pubkey hash.
-    /// - For segwit addresses, the payload is the witness program.
     fn payload_as_bytes(&self) -> &[u8] {
         use AddressInner::*;
         match self.0 {
@@ -616,14 +570,6 @@ impl FromStr for Address<NetworkUnchecked> {
     }
 }
 
-/// Convert a byte array of a pubkey hash into a segwit redeem hash
-fn segwit_redeem_hash(pubkey_hash: &PubkeyHash) -> crate::hashes::hash160::Hash {
-    let mut sha_engine = sha256::Hash::engine();
-    sha_engine.input(&[0, 20]);
-    sha_engine.input(pubkey_hash.as_ref());
-    crate::hashes::hash160::Hash::from_engine(sha_engine)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -656,7 +602,7 @@ mod tests {
     #[test]
     fn test_p2pkh_address_58() {
         let hash = "162c5ea71c0b23f5b9022ef047c4a86470a5b070".parse::<PubkeyHash>().unwrap();
-        let addr = Address::p2pkh(hash, Network::Dogecoin);
+        let addr = Address::p2pkh(hash, Dogecoin);
 
         assert_eq!(
             addr.script_pubkey(),
@@ -670,13 +616,13 @@ mod tests {
     #[test]
     fn test_p2pkh_from_key() {
         let key = "048d5141948c1702e8c95f438815794b87f706a8d4cd2bffad1dc1570971032c9b6042a0431ded2478b5c9cf2d81c124a5e57347a3c63ef0e7716cf54d613ba183".parse::<PublicKey>().unwrap();
-        let addr = Address::p2pkh(key, Network::Dogecoin);
+        let addr = Address::p2pkh(key, Dogecoin);
         assert_eq!(&addr.to_string(), "DUSamFaUtRQ78DVidoeY3J8keYkQXdinrt");
 
         let key = "03df154ebfcf29d29cc10d5c2565018bce2d9edbab267c31d2caf44a63056cf99f"
             .parse::<PublicKey>()
             .unwrap();
-        let addr = Address::p2pkh(key, Network::Testnet);
+        let addr = Address::p2pkh(key, Testnet);
         assert_eq!(&addr.to_string(), "neRuCZsfnZaJN8FmxxVZDSZbcGATnzGByf");
         assert_eq!(addr.address_type(), Some(AddressType::P2pkh));
         roundtrips(&addr, Testnet);
@@ -685,7 +631,7 @@ mod tests {
     #[test]
     fn test_p2sh_address_58() {
         let hash = "162c5ea71c0b23f5b9022ef047c4a86470a5b070".parse::<ScriptHash>().unwrap();
-        let addr = Address::p2sh_from_hash(hash, Network::Dogecoin);
+        let addr = Address::p2sh_from_hash(hash, Dogecoin);
 
         assert_eq!(
             addr.script_pubkey(),
@@ -699,7 +645,7 @@ mod tests {
     #[test]
     fn test_p2sh_parse() {
         let script = ScriptBuf::from_hex("552103a765fc35b3f210b95223846b36ef62a4e53e34e2925270c2c7906b92c9f718eb2103c327511374246759ec8d0b89fa6c6b23b33e11f92c5bc155409d86de0c79180121038cae7406af1f12f4786d820a1466eec7bc5785a1b5e4a387eca6d797753ef6db2103252bfb9dcaab0cd00353f2ac328954d791270203d66c2be8b430f115f451b8a12103e79412d42372c55dd336f2eb6eb639ef9d74a22041ba79382c74da2338fe58ad21035049459a4ebc00e876a9eef02e72a3e70202d3d1f591fc0dd542f93f642021f82102016f682920d9723c61b27f562eb530c926c00106004798b6471e8c52c60ee02057ae").unwrap();
-        let addr = Address::p2sh(&script, Network::Testnet).unwrap();
+        let addr = Address::p2sh(&script, Testnet).unwrap();
         assert_eq!(&addr.to_string(), "2N3zXjbwdTcPsJiy8sUK9FhWJhqQCxA8Jjr");
         assert_eq!(addr.address_type(), Some(AddressType::P2sh));
         roundtrips(&addr, Testnet);
@@ -708,7 +654,7 @@ mod tests {
     #[test]
     fn test_p2sh_parse_for_large_script() {
         let script = ScriptBuf::from_hex("552103a765fc35b3f210b95223846b36ef62a4e53e34e2925270c2c7906b92c9f718eb2103c327511374246759ec8d0b89fa6c6b23b33e11f92c5bc155409d86de0c79180121038cae7406af1f12f4786d820a1466eec7bc5785a1b5e4a387eca6d797753ef6db2103252bfb9dcaab0cd00353f2ac328954d791270203d66c2be8b430f115f451b8a12103e79412d42372c55dd336f2eb6eb639ef9d74a22041ba79382c74da2338fe58ad21035049459a4ebc00e876a9eef02e72a3e70202d3d1f591fc0dd542f93f642021f82102016f682920d9723c61b27f562eb530c926c00106004798b6471e8c52c60ee02057ae12123122313123123ac1231231231231313123131231231231313212313213123123552103a765fc35b3f210b95223846b36ef62a4e53e34e2925270c2c7906b92c9f718eb2103c327511374246759ec8d0b89fa6c6b23b33e11f92c5bc155409d86de0c79180121038cae7406af1f12f4786d820a1466eec7bc5785a1b5e4a387eca6d797753ef6db2103252bfb9dcaab0cd00353f2ac328954d791270203d66c2be8b430f115f451b8a12103e79412d42372c55dd336f2eb6eb639ef9d74a22041ba79382c74da2338fe58ad21035049459a4ebc00e876a9eef02e72a3e70202d3d1f591fc0dd542f93f642021f82102016f682920d9723c61b27f562eb530c926c00106004798b6471e8c52c60ee02057ae12123122313123123ac1231231231231313123131231231231313212313213123123552103a765fc35b3f210b95223846b36ef62a4e53e34e2925270c2c7906b92c9f718eb2103c327511374246759ec8d0b89fa6c6b23b33e11f92c5bc155409d86de0c79180121038cae7406af1f12f4786d820a1466eec7bc5785a1b5e4a387eca6d797753ef6db2103252bfb9dcaab0cd00353f2ac328954d791270203d66c2be8b430f115f451b8a12103e79412d42372c55dd336f2eb6eb639ef9d74a22041ba79382c74da2338fe58ad21035049459a4ebc00e876a9eef02e72a3e70202d3d1f591fc0dd542f93f642021f82102016f682920d9723c61b27f562eb530c926c00106004798b6471e8c52c60ee02057ae12123122313123123ac1231231231231313123131231231231313212313213123123").unwrap();
-        assert_eq!(Address::p2sh(&script, Network::Testnet), Err(P2shError::ExcessiveScriptSize));
+        assert_eq!(Address::p2sh(&script, Testnet), Err(P2shError::ExcessiveScriptSize));
     }
 
     #[test]
@@ -742,10 +688,8 @@ mod tests {
             ("A1yb6viUzAcUWftRHT6GpnCwvhXHg4CV1x", Some(AddressType::P2sh)),
         ];
         for (address, expected_type) in &addresses {
-            let addr = Address::from_str(address)
-                .unwrap()
-                .require_network(Network::Dogecoin)
-                .expect("mainnet");
+            let addr =
+                Address::from_str(address).unwrap().require_network(Dogecoin).expect("mainnet");
             assert_eq!(&addr.address_type(), expected_type);
         }
     }
@@ -789,7 +733,7 @@ mod tests {
         let address_string = "neRuCZsfnZaJN8FmxxVZDSZbcGATnzGByf";
         let address = Address::from_str(address_string)
             .expect("address")
-            .require_network(Network::Testnet)
+            .require_network(Testnet)
             .expect("testnet");
 
         let pubkey_string = "03df154ebfcf29d29cc10d5c2565018bce2d9edbab267c31d2caf44a63056cf99f";
@@ -810,7 +754,7 @@ mod tests {
         let address_string = "DUSamFaUtRQ78DVidoeY3J8keYkQXdinrt";
         let address = Address::from_str(address_string)
             .expect("address")
-            .require_network(Network::Dogecoin)
+            .require_network(Dogecoin)
             .expect("mainnet");
 
         let pubkey_string = "048d5141948c1702e8c95f438815794b87f706a8d4cd2bffad1dc1570971032c9b6042a0431ded2478b5c9cf2d81c124a5e57347a3c63ef0e7716cf54d613ba183";

--- a/bitcoin/src/dogecoin/address/mod.rs
+++ b/bitcoin/src/dogecoin/address/mod.rs
@@ -559,6 +559,10 @@ impl FromStr for Address<NetworkUnchecked> {
                 let hash = ScriptHash::from_byte_array(data);
                 AddressInner::P2sh { hash, network: Network::Dogecoin }
             }
+            // Because SCRIPT_ADDRESS_PREFIX_TESTNET and SCRIPT_ADDRESS_PREFIX_REGTTEST are
+            // the same, we do not differentiate between Testnet and Regtest only when it is P2sh.
+            // This is handled in function is_valid_for_network (its docstring has more
+            // explanation).
             SCRIPT_ADDRESS_PREFIX_TESTNET => {
                 let hash = ScriptHash::from_byte_array(data);
                 AddressInner::P2sh { hash, network: Network::Testnet }

--- a/bitcoin/src/dogecoin/address/mod.rs
+++ b/bitcoin/src/dogecoin/address/mod.rs
@@ -43,7 +43,6 @@ use crate::dogecoin::constants::{
     SCRIPT_ADDRESS_PREFIX_MAINNET, SCRIPT_ADDRESS_PREFIX_REGTEST, SCRIPT_ADDRESS_PREFIX_TESTNET,
 };
 use crate::dogecoin::Network;
-use crate::prelude::*;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
@@ -376,11 +375,6 @@ impl Address {
             P2pkh { ref hash, network: _ } => ScriptBuf::new_p2pkh(hash),
             P2sh { ref hash, network: _ } => ScriptBuf::new_p2sh(hash),
         }
-    }
-
-    /// Creates a URI string *bitcoin:address* optimized to be encoded in QR codes.
-    pub fn to_qr_uri(&self) -> String {
-        format!("bitcoin:{:#}", self)
     }
 
     /// Returns true if the given pubkey is directly related to the address payload.

--- a/bitcoin/src/dogecoin/constants.rs
+++ b/bitcoin/src/dogecoin/constants.rs
@@ -18,6 +18,13 @@ use crate::{
     TxMerkleNode, TxOut, Witness,
 };
 
+pub const PUBKEY_ADDRESS_PREFIX_MAINNET : u8 = 0x1e;
+pub const PUBKEY_ADDRESS_PREFIX_TESTNET : u8 = 0x71;
+pub const PUBKEY_ADDRESS_PREFIX_REGTEST : u8 = 0x6f;
+pub const SCRIPT_ADDRESS_PREFIX_MAINNET : u8 = 0x16;
+pub const SCRIPT_ADDRESS_PREFIX_TESTNET : u8 = 0xc4;
+pub const SCRIPT_ADDRESS_PREFIX_REGTEST : u8 = 0xc4;
+
 // This is the 65 byte (uncompressed) pubkey used as the one-and-only output of the genesis transaction.
 //
 // ref: https://github.com/dogecoin/dogecoin/blob/7237da74b8c356568644cbe4fba19d994704355b/src/chainparams.cpp#L55

--- a/bitcoin/src/dogecoin/constants.rs
+++ b/bitcoin/src/dogecoin/constants.rs
@@ -18,12 +18,12 @@ use crate::{
     TxMerkleNode, TxOut, Witness,
 };
 
-pub const PUBKEY_ADDRESS_PREFIX_MAINNET : u8 = 0x1e;
-pub const PUBKEY_ADDRESS_PREFIX_TESTNET : u8 = 0x71;
-pub const PUBKEY_ADDRESS_PREFIX_REGTEST : u8 = 0x6f;
-pub const SCRIPT_ADDRESS_PREFIX_MAINNET : u8 = 0x16;
-pub const SCRIPT_ADDRESS_PREFIX_TESTNET : u8 = 0xc4;
-pub const SCRIPT_ADDRESS_PREFIX_REGTEST : u8 = 0xc4;
+pub(crate) const PUBKEY_ADDRESS_PREFIX_MAINNET : u8 = 0x1e;
+pub(crate) const PUBKEY_ADDRESS_PREFIX_TESTNET : u8 = 0x71;
+pub(crate) const PUBKEY_ADDRESS_PREFIX_REGTEST : u8 = 0x6f;
+pub(crate) const SCRIPT_ADDRESS_PREFIX_MAINNET : u8 = 0x16;
+pub(crate) const SCRIPT_ADDRESS_PREFIX_TESTNET : u8 = 0xc4;
+pub(crate) const SCRIPT_ADDRESS_PREFIX_REGTEST : u8 = 0xc4;
 
 // This is the 65 byte (uncompressed) pubkey used as the one-and-only output of the genesis transaction.
 //

--- a/bitcoin/src/dogecoin/mod.rs
+++ b/bitcoin/src/dogecoin/mod.rs
@@ -19,10 +19,15 @@ use crate::prelude::*;
 use crate::{io, BlockHash, Transaction};
 use core::fmt;
 
+pub mod address;
+pub use address::*;
+
 /// AuxPow version bit, see <https://github.com/dogecoin/dogecoin/blob/d7cc7f8bbb5f790942d0ed0617f62447e7675233/src/primitives/pureheader.h#L23>
 pub const VERSION_AUXPOW: i32 = 1 << 8;
 
-fn is_auxpow(header: Header) -> bool { (header.version.to_consensus() & VERSION_AUXPOW) != 0 }
+fn is_auxpow(header: Header) -> bool {
+    (header.version.to_consensus() & VERSION_AUXPOW) != 0
+}
 
 /// Data for merge-mining AuxPoW.
 ///
@@ -87,7 +92,9 @@ pub struct Block {
 
 impl Block {
     /// Returns the block hash computed as SHA256d(header).
-    pub fn block_hash(&self) -> BlockHash { self.header.block_hash() }
+    pub fn block_hash(&self) -> BlockHash {
+        self.header.block_hash()
+    }
 
     /// Returns the block hash using the scrypt hash function.
     pub fn block_hash_with_scrypt(&self) -> BlockHash { self.header.block_hash_with_scrypt() }
@@ -331,7 +338,7 @@ mod tests {
             assert_eq!(serialize(&header.block_hash_with_scrypt()), test.output);
         }
     }
-    
+
     #[test]
     fn max_target_from_compact() {
         // The highest possible target in Dogecoin is defined as 0x1e0fffff

--- a/bitcoin/src/dogecoin/mod.rs
+++ b/bitcoin/src/dogecoin/mod.rs
@@ -13,11 +13,11 @@ pub use address::*;
 
 use crate::block::{Header, TxMerkleNode};
 use crate::consensus::{encode, Decodable, Encodable};
-use crate::params::Params as BitcoinParams;
 use crate::dogecoin::params::Params;
 use crate::internal_macros::impl_consensus_encoding;
 use crate::io::{Read, Write};
 use crate::p2p::Magic;
+use crate::params::Params as BitcoinParams;
 use crate::prelude::*;
 use crate::{io, BlockHash, Transaction};
 use core::fmt;
@@ -97,7 +97,9 @@ impl Block {
     }
 
     /// Returns the block hash using the scrypt hash function.
-    pub fn block_hash_with_scrypt(&self) -> BlockHash { self.header.block_hash_with_scrypt() }
+    pub fn block_hash_with_scrypt(&self) -> BlockHash {
+        self.header.block_hash_with_scrypt()
+    }
 
     /// Checks if merkle root of header matches merkle root of the transaction list.
     pub fn check_merkle_root(&self) -> bool {
@@ -109,10 +111,7 @@ impl Block {
 
     /// Compute merkle root of the transaction list in this block.
     pub fn compute_merkle_root(&self) -> Option<TxMerkleNode> {
-        let hashes = self
-            .txdata
-            .iter()
-            .map(|obj| obj.compute_txid().to_raw_hash());
+        let hashes = self.txdata.iter().map(|obj| obj.compute_txid().to_raw_hash());
         crate::merkle_tree::calculate_root(hashes).map(|h| h.into())
     }
 }

--- a/bitcoin/src/dogecoin/mod.rs
+++ b/bitcoin/src/dogecoin/mod.rs
@@ -25,9 +25,7 @@ use core::fmt;
 /// AuxPow version bit, see <https://github.com/dogecoin/dogecoin/blob/d7cc7f8bbb5f790942d0ed0617f62447e7675233/src/primitives/pureheader.h#L23>
 pub const VERSION_AUXPOW: i32 = 1 << 8;
 
-fn is_auxpow(header: Header) -> bool {
-    (header.version.to_consensus() & VERSION_AUXPOW) != 0
-}
+fn is_auxpow(header: Header) -> bool { (header.version.to_consensus() & VERSION_AUXPOW) != 0 }
 
 /// Data for merge-mining AuxPoW.
 ///
@@ -92,14 +90,10 @@ pub struct Block {
 
 impl Block {
     /// Returns the block hash computed as SHA256d(header).
-    pub fn block_hash(&self) -> BlockHash {
-        self.header.block_hash()
-    }
+    pub fn block_hash(&self) -> BlockHash { self.header.block_hash() }
 
     /// Returns the block hash using the scrypt hash function.
-    pub fn block_hash_with_scrypt(&self) -> BlockHash {
-        self.header.block_hash_with_scrypt()
-    }
+    pub fn block_hash_with_scrypt(&self) -> BlockHash { self.header.block_hash_with_scrypt() }
 
     /// Checks if merkle root of header matches merkle root of the transaction list.
     pub fn check_merkle_root(&self) -> bool {
@@ -111,7 +105,10 @@ impl Block {
 
     /// Compute merkle root of the transaction list in this block.
     pub fn compute_merkle_root(&self) -> Option<TxMerkleNode> {
-        let hashes = self.txdata.iter().map(|obj| obj.compute_txid().to_raw_hash());
+        let hashes = self
+            .txdata
+            .iter()
+            .map(|obj| obj.compute_txid().to_raw_hash());
         crate::merkle_tree::calculate_root(hashes).map(|h| h.into())
     }
 }
@@ -337,7 +334,7 @@ mod tests {
             assert_eq!(serialize(&header.block_hash_with_scrypt()), test.output);
         }
     }
-
+    
     #[test]
     fn max_target_from_compact() {
         // The highest possible target in Dogecoin is defined as 0x1e0fffff

--- a/bitcoin/src/dogecoin/mod.rs
+++ b/bitcoin/src/dogecoin/mod.rs
@@ -5,8 +5,11 @@
 //! This module provides support for de/serialization, parsing and execution on data structures and
 //! network messages related to Dogecoin.
 
+pub mod address;
 pub mod constants;
 pub mod params;
+
+pub use address::*;
 
 use crate::block::{Header, TxMerkleNode};
 use crate::consensus::{encode, Decodable, Encodable};
@@ -18,9 +21,6 @@ use crate::p2p::Magic;
 use crate::prelude::*;
 use crate::{io, BlockHash, Transaction};
 use core::fmt;
-
-pub mod address;
-pub use address::*;
 
 /// AuxPow version bit, see <https://github.com/dogecoin/dogecoin/blob/d7cc7f8bbb5f790942d0ed0617f62447e7675233/src/primitives/pureheader.h#L23>
 pub const VERSION_AUXPOW: i32 = 1 << 8;


### PR DESCRIPTION
Since dogecoin uses different prefixes and only supports P2PKH and P2SH address types, this PR introduces separate implementations for Address related types, which are adapted from the bitcoin ones.