### PR TITLE
feat: Support dogecoin in p2p messages

### DIFF
--- a/bitcoin/examples/handshake.rs
+++ b/bitcoin/examples/handshake.rs
@@ -9,6 +9,9 @@ use bitcoin::consensus::{encode, Decodable};
 use bitcoin::p2p::{self, address, message, message_network};
 use bitcoin::secp256k1::rand::Rng;
 
+type NetworkMessage = message::NetworkMessage<bitcoin::Block>;
+type RawNetworkMessage = message::RawNetworkMEssage<bitcoin::Block>;
+
 fn main() {
     // This example establishes a connection to a Bitcoin node, sends the initial
     // "version" message, waits for the reply, and finally closes the connection.
@@ -28,7 +31,7 @@ fn main() {
     let version_message = build_version_message(address);
 
     let first_message =
-        message::RawNetworkMessage::new(bitcoin::Network::Bitcoin.magic(), version_message);
+        RawNetworkMessage::new(bitcoin::Network::Bitcoin.magic(), version_message);
 
     if let Ok(mut stream) = TcpStream::connect(address) {
         // Send the message
@@ -40,20 +43,20 @@ fn main() {
         let mut stream_reader = BufReader::new(read_stream);
         loop {
             // Loop an retrieve new messages
-            let reply = message::RawNetworkMessage::consensus_decode(&mut stream_reader).unwrap();
+            let reply = RawNetworkMessage::consensus_decode(&mut stream_reader).unwrap();
             match reply.payload() {
-                message::NetworkMessage::Version(_) => {
+                NetworkMessage::Version(_) => {
                     println!("Received version message: {:?}", reply.payload());
 
-                    let second_message = message::RawNetworkMessage::new(
+                    let second_message = RawNetworkMessage::new(
                         bitcoin::Network::Bitcoin.magic(),
-                        message::NetworkMessage::Verack,
+                        NetworkMessage::Verack,
                     );
 
                     let _ = stream.write_all(encode::serialize(&second_message).as_slice());
                     println!("Sent verack message");
                 }
-                message::NetworkMessage::Verack => {
+                NetworkMessage::Verack => {
                     println!("Received verack message: {:?}", reply.payload());
                     break;
                 }
@@ -69,7 +72,7 @@ fn main() {
     }
 }
 
-fn build_version_message(address: SocketAddr) -> message::NetworkMessage {
+fn build_version_message(address: SocketAddr) -> NetworkMessage {
     // Building version message, see https://en.bitcoin.it/wiki/Protocol_documentation#version
     let my_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0);
 
@@ -95,7 +98,7 @@ fn build_version_message(address: SocketAddr) -> message::NetworkMessage {
     let start_height: i32 = 0;
 
     // Construct the message
-    message::NetworkMessage::Version(message_network::VersionMessage::new(
+    NetworkMessage::Version(message_network::VersionMessage::new(
         services,
         timestamp as i64,
         addr_recv,

--- a/bitcoin/examples/handshake.rs
+++ b/bitcoin/examples/handshake.rs
@@ -10,7 +10,7 @@ use bitcoin::p2p::{self, address, message, message_network};
 use bitcoin::secp256k1::rand::Rng;
 
 type NetworkMessage = message::NetworkMessage<bitcoin::Block>;
-type RawNetworkMessage = message::RawNetworkMEssage<bitcoin::Block>;
+type RawNetworkMessage = message::RawNetworkMessage<bitcoin::Block>;
 
 fn main() {
     // This example establishes a connection to a Bitcoin node, sends the initial

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -145,14 +145,16 @@ impl fmt::Display for CommandStringError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for CommandStringError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
 }
 
 /// A Network message
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct RawNetworkMessage {
+pub struct RawNetworkMessage<Block> {
     magic: Magic,
-    payload: NetworkMessage,
+    payload: NetworkMessage<Block>,
     payload_len: u32,
     checksum: [u8; 4],
 }
@@ -160,7 +162,7 @@ pub struct RawNetworkMessage {
 /// A Network message payload. Proper documentation is available on at
 /// [Bitcoin Wiki: Protocol Specification](https://en.bitcoin.it/wiki/Protocol_specification)
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub enum NetworkMessage {
+pub enum NetworkMessage<Block> {
     /// `version`
     Version(message_network::VersionMessage),
     /// `verack`
@@ -182,7 +184,7 @@ pub enum NetworkMessage {
     /// tx
     Tx(transaction::Transaction),
     /// `block`
-    Block(block::Block),
+    Block(Block),
     /// `headers`
     Headers(Vec<block::Header>),
     /// `sendheaders`
@@ -243,7 +245,7 @@ pub enum NetworkMessage {
     },
 }
 
-impl NetworkMessage {
+impl<Block> NetworkMessage<Block> {
     /// Return the message command as a static string reference.
     ///
     /// This returns `"unknown"` for [NetworkMessage::Unknown],
@@ -300,9 +302,9 @@ impl NetworkMessage {
     }
 }
 
-impl RawNetworkMessage {
+impl<Block: Encodable> RawNetworkMessage<Block> {
     /// Creates a [RawNetworkMessage]
-    pub fn new(magic: Magic, payload: NetworkMessage) -> Self {
+    pub fn new(magic: Magic, payload: NetworkMessage<Block>) -> Self {
         let mut engine = sha256d::Hash::engine();
         let payload_len = payload.consensus_encode(&mut engine).expect("engine doesn't error");
         let payload_len = u32::try_from(payload_len).expect("network message use u32 as length");
@@ -312,12 +314,14 @@ impl RawNetworkMessage {
     }
 
     /// Consumes the [RawNetworkMessage] instance and returns the inner payload.
-    pub fn into_payload(self) -> NetworkMessage {
+    pub fn into_payload(self) -> NetworkMessage<Block> {
         self.payload
     }
 
     /// The actual message data
-    pub fn payload(&self) -> &NetworkMessage { &self.payload }
+    pub fn payload(&self) -> &NetworkMessage<Block> {
+        &self.payload
+    }
 
     /// Magic bytes to identify the network these messages are meant for
     pub fn magic(&self) -> &Magic { &self.magic }
@@ -348,7 +352,7 @@ impl<'a> Encodable for HeaderSerializationWrapper<'a> {
     }
 }
 
-impl Encodable for NetworkMessage {
+impl<Block: Encodable> Encodable for NetworkMessage<Block> {
     fn consensus_encode<W: Write + ?Sized>(&self, writer: &mut W) -> Result<usize, io::Error> {
         match self {
             NetworkMessage::Version(ref dat) => dat.consensus_encode(writer),
@@ -393,7 +397,7 @@ impl Encodable for NetworkMessage {
     }
 }
 
-impl Encodable for RawNetworkMessage {
+impl<Block: Encodable> Encodable for RawNetworkMessage<Block> {
     fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         let mut len = 0;
         len += self.magic.consensus_encode(w)?;
@@ -433,7 +437,7 @@ impl Decodable for HeaderDeserializationWrapper {
     }
 }
 
-impl Decodable for RawNetworkMessage {
+impl<Block: Decodable> Decodable for RawNetworkMessage<Block> {
     fn consensus_decode_from_finite_reader<R: Read + ?Sized>(
         r: &mut R,
     ) -> Result<Self, encode::Error> {
@@ -547,7 +551,7 @@ mod test {
     use hex::test_hex_unwrap as hex;
 
     use super::message_network::{Reject, RejectReason, VersionMessage};
-    use super::*;
+    use super::{block, AddrV2Message, Address, CommandString, Magic, MerkleBlock};
     use crate::bip152::BlockTransactionsRequest;
     use crate::blockdata::block::Block;
     use crate::blockdata::script::ScriptBuf;
@@ -562,7 +566,12 @@ mod test {
     };
     use crate::p2p::ServiceFlags;
 
-    fn hash(slice: [u8; 32]) -> Hash { Hash::from_slice(&slice).unwrap() }
+    type NetworkMessage = super::NetworkMessage<Block>;
+    type RawNetworkMessage = super::RawNetworkMessage<Block>;
+
+    fn hash(slice: [u8; 32]) -> Hash {
+        Hash::from_slice(&slice).unwrap()
+    }
 
     #[test]
     fn full_round_ser_der_raw_network_message_test() {

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -145,9 +145,7 @@ impl fmt::Display for CommandStringError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for CommandStringError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        None
-    }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
 }
 
 /// A Network message

--- a/bitcoin/src/p2p/message_blockdata.rs
+++ b/bitcoin/src/p2p/message_blockdata.rs
@@ -130,6 +130,10 @@ impl GetBlocksMessage {
     pub fn new(locator_hashes: Vec<BlockHash>, stop_hash: BlockHash) -> GetBlocksMessage {
         GetBlocksMessage { version: p2p::PROTOCOL_VERSION, locator_hashes, stop_hash }
     }
+    /// Set the version number.
+    pub fn with_version(self, version: u32) -> Self {
+        Self { version, ..self }
+    }
 }
 
 impl_consensus_encoding!(GetBlocksMessage, version, locator_hashes, stop_hash);
@@ -138,6 +142,10 @@ impl GetHeadersMessage {
     /// Construct a new `getheaders` message
     pub fn new(locator_hashes: Vec<BlockHash>, stop_hash: BlockHash) -> GetHeadersMessage {
         GetHeadersMessage { version: p2p::PROTOCOL_VERSION, locator_hashes, stop_hash }
+    }
+    /// Set the version number.
+    pub fn with_version(self, version: u32) -> Self {
+        Self { version, ..self }
     }
 }
 

--- a/bitcoin/src/p2p/message_network.rs
+++ b/bitcoin/src/p2p/message_network.rs
@@ -73,6 +73,10 @@ impl VersionMessage {
             relay: false,
         }
     }
+    /// Set the version number.
+    pub fn with_version(self, version: u32) -> Self {
+        Self { version, ..self }
+    }
 }
 
 impl_consensus_encoding!(

--- a/fuzz/fuzz_targets/bitcoin/deser_net_msg.rs
+++ b/fuzz/fuzz_targets/bitcoin/deser_net_msg.rs
@@ -1,7 +1,7 @@
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {
-    let _: Result<bitcoin::p2p::message::RawNetworkMessage, _> =
+    let _: Result<bitcoin::p2p::message::RawNetworkMessage<bitcoin::Block>, _> =
         bitcoin::consensus::encode::deserialize(data);
 }
 


### PR DESCRIPTION
Support dogecoin in p2p messages by making NetworkMessage type parameterized by Block type.

Also add `with_version()` methods to a few types to allow changing protocol version number.