### PR TITLE
feat(dogecoin): add methods required for implementing dogecoin's difficulty adjustment algorithm

### DIFF
--- a/bitcoin/src/dogecoin/mod.rs
+++ b/bitcoin/src/dogecoin/mod.rs
@@ -160,11 +160,14 @@ mod tests {
     use super::*;
     use crate::block::{ValidationError, Version};
     use crate::consensus::encode::{deserialize, serialize};
-    use crate::{CompactTarget, Network, Target, Work};
+    use crate::{CompactTarget, Target, Work};
+    use crate::params::{Params as BitcoinParams};
+    use crate::{Network as BitcoinNetwork};
+    use float_cmp::approx_eq;
+
 
     #[test]
     fn dogecoin_block_test() {
-        let params = crate::consensus::Params::new(Network::Bitcoin);
         // Mainnet Dogecoin block 5794c80b80d9c33e0737a5353cd52b1f097f61d8d2b9f471e1702345080e0002
         let some_block = hex!("01000000c76fe7f8ec09989d32b7907966fbd347134f80a7b71efce55fec502aa126ba3894b3065289ff8ba1ab4e8391771174d47cf2c974ebd24a1bdafd6c107d5a7a207d78bb52de8f001c00da8c3c0201000000010000000000000000000000000000000000000000000000000000000000000000ffffffff2602bc6d062f503253482f047178bb5208f8042975030000000d2f7374726174756d506f6f6c2f000000000100629b29c45500001976a91450e9fe87c705dcd4b7523b47e3314c2115f5d5df88ac0000000001000000015f48fabf4425324df2b5e58f4e9c771297f76f5fa37db7556f6fc1d22742da1f010000006a473044022062d29d2d26f7d826e7b72257486e294d284832743c7803a2901eb07e326b25a002207efc391b0f4e724c9d518075c0e056cc425540f845b0fd419ba8a9d49d69288301210297a2568525760a98454d84f5e5adba9fd0a41726a6fb774ddc407279e41e2061ffffffff0240bab598200000001976a91401348a2b83aeb6b1ba2a174a1a40b7c75fbeb12088ac0040be40250000001976a914025407d928ef333979d064ae233353d80e29d58c88ac00000000");
         let cutoff_block = hex!("01000000c76fe7f8ec09989d32b7907966fbd347134f80a7b71efce55fec502aa126ba3894b3065289ff8ba1ab4e8391771174d47cf2c974ebd24a1bdafd6c107d5a7a207d78bb52de8f001c00da8c3c0201000000010000000000000000000000000000000000000000000000000000000000000000ffffffff2602bc6d062f503253482f047178bb5208f8042975030000000d2f7374726174756d506f6f6c2f000000000100629b29c45500001976a91450e9fe87c705dcd4b7523b47e3314c2115f5d5df88ac0000000001000000015f48fabf4425324df2b5e58f4e9c771297f76f5fa37db7556f6fc1d22742da1f010000006a473044022062d29d2d26f7d826e7b72257486e294d284832743c7803a2901eb07e326b25a002207efc391b0f4e724c9d518075c0e056cc425540f845b0fd419ba8a9d49d69288301210297a2568525760a98454d84f5e5adba9fd0a41726a6fb774ddc407279e41e2061ffffffff0240bab598200000001976a91401348a2b83aeb6b1ba2a174a1a40b7c75fbeb12088ac0040be40250000001976a914025407d928ef333979d064ae233353d80e29d58c88ac");
@@ -193,7 +196,9 @@ mod tests {
             real_decode.header.validate_pow_with_scrypt(real_decode.header.target()).unwrap(),
             real_decode.block_hash_with_scrypt()
         );
-        assert_eq!(real_decode.header.difficulty(&params), 455);
+        // Bitcoin parameters are used because Dogecoin's difficulty calculation is the same as Bitcoin,
+        // which depends on Bitcoin's `max_attainable_target` value
+        assert_eq!(real_decode.header.difficulty(&BitcoinParams::new(BitcoinNetwork::Bitcoin)), 455);
         assert_eq!(real_decode.header.difficulty_float(), 455.52430084170516);
 
         assert_eq!(serialize(&real_decode), some_block);
@@ -282,5 +287,125 @@ mod tests {
         let want = Target::MAX_ATTAINABLE_MAINNET_DOGE;
         let got = Target::from_compact(CompactTarget::from_consensus(bits));
         assert_eq!(got, want)
+    }
+
+    #[test]
+    fn compact_target_from_upwards_difficulty_adjustment() {
+        let params = Params::new(Network::Dogecoin);
+        let starting_bits = CompactTarget::from_consensus(0x1e0ffff0); // Genesis compact target on Mainnet
+        let start_time: u64 = 1386325540; // Genesis block unix time
+        let end_time: u64 = 1386475638; // Block 239 unix time
+        let timespan = end_time - start_time; // Slower than expected (150,098 seconds diff)
+        let adjustment = CompactTarget::from_next_work_required_dogecoin(starting_bits, timespan, &params);
+        let adjustment_bits = CompactTarget::from_consensus(0x1e0fffff); // Block 240 compact target
+        assert_eq!(adjustment, adjustment_bits);
+    }
+
+    #[test]
+    fn compact_target_from_downwards_difficulty_adjustment() {
+        let params = Params::new(Network::Dogecoin);
+        let starting_bits = CompactTarget::from_consensus(0x1e0fffff); // Block 240 compact target
+        let start_time: u64 = 1386475638; // Block 239 unix time
+        let end_time: u64 = 1386475840; // Block 479 unix time
+        let timespan = end_time - start_time; // Faster than expected (202 seconds diff)
+        let adjustment = CompactTarget::from_next_work_required_dogecoin(starting_bits, timespan, &params);
+        let adjustment_bits = CompactTarget::from_consensus(0x1e00ffff); // Block 480 compact target
+        assert_eq!(adjustment, adjustment_bits);
+    }
+
+    #[test]
+    fn compact_target_from_downwards_difficulty_adjustment_using_headers() {
+        use crate::{block::Version, dogecoin::constants::genesis_block, TxMerkleNode};
+        use hashes::Hash;
+        let params = Params::new(Network::Dogecoin);
+        let epoch_start = genesis_block(&params).header;
+        // Block 239, the only information used are `bits` and `time`
+        let current = Header {
+            version: Version::ONE,
+            prev_blockhash: BlockHash::all_zeros(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 1386475638,
+            bits: epoch_start.bits,
+            nonce: epoch_start.nonce
+        };
+        let adjustment = CompactTarget::from_header_difficulty_adjustment_dogecoin(epoch_start, current, params);
+        let adjustment_bits = CompactTarget::from_consensus(0x1e0fffff); // Block 240 compact target
+        assert_eq!(adjustment, adjustment_bits);
+    }
+
+    #[test]
+    fn compact_target_from_upwards_difficulty_adjustment_using_headers() {
+        use crate::{block::Version, TxMerkleNode};
+        use hashes::Hash;
+        let params = Params::new(Network::Dogecoin);
+        let starting_bits = CompactTarget::from_consensus(0x1e0fffff); // Block 479 compact target
+        // Block 239, the only information used is `time`
+        let epoch_start = Header {
+            version: Version::ONE,
+            prev_blockhash: BlockHash::all_zeros(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 1386475638,
+            bits: starting_bits,
+            nonce: 0
+        };
+        // Block 479, the only information used are `bits` and `time`
+        let current = Header {
+            version: Version::ONE,
+            prev_blockhash: BlockHash::all_zeros(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 1386475840,
+            bits: starting_bits,
+            nonce: 0
+        };
+        let adjustment = CompactTarget::from_header_difficulty_adjustment_dogecoin(epoch_start, current, params);
+        let adjustment_bits = CompactTarget::from_consensus(0x1e00ffff); // Block 480 compact target
+        assert_eq!(adjustment, adjustment_bits);
+    }
+
+    #[test]
+    fn compact_target_from_maximum_upward_difficulty_adjustment() {
+        let params = Params::new(Network::Dogecoin);
+        let starting_bits = CompactTarget::from_consensus(21403001); // Arbitrary difficulty
+        let timespan = (0.06 * params.bitcoin_params.pow_target_timespan as f64) as u64; // > 16x Faster than expected
+        let got = CompactTarget::from_next_work_required_dogecoin(starting_bits, timespan, params);
+        let want = Target::from_compact(starting_bits)
+            .min_transition_threshold_dogecoin(5000)
+            .to_compact_lossy();
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn compact_target_from_minimum_downward_difficulty_adjustment() {
+        let params = Params::new(Network::Dogecoin);
+        let starting_bits = CompactTarget::from_consensus(21403001); // Arbitrary difficulty
+        let timespan =  5 * params.bitcoin_params.pow_target_timespan; // > 4x Slower than expected
+        let got = CompactTarget::from_next_work_required_dogecoin(starting_bits, timespan, &params);
+        let want = Target::from_compact(starting_bits)
+            .max_transition_threshold(params)
+            .to_compact_lossy();
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn compact_target_from_adjustment_is_max_target() {
+        let params = Params::new(Network::Dogecoin);
+        let starting_bits = CompactTarget::from_consensus(0x1e0fffff); // Block 240 compact target (max target)
+        let timespan =  5 * params.bitcoin_params.pow_target_timespan; // > 4x Slower than expected
+        let got = CompactTarget::from_next_work_required(starting_bits, timespan, &params);
+        let want = params.bitcoin_params.max_attainable_target.to_compact_lossy();
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn roundtrip_compact_target() {
+        let consensus = 0x1e0f_ffff;
+        let compact = CompactTarget::from_consensus(consensus);
+        let t = Target::from_compact(CompactTarget::from_consensus(consensus));
+        assert_eq!(t, Target::from(compact)); // From/Into sanity check.
+
+        let back = t.to_compact_lossy();
+        assert_eq!(back, compact); // From/Into sanity check.
+
+        assert_eq!(back.to_consensus(), consensus);
     }
 }

--- a/bitcoin/src/dogecoin/mod.rs
+++ b/bitcoin/src/dogecoin/mod.rs
@@ -163,7 +163,6 @@ mod tests {
     use crate::{CompactTarget, Target, Work};
     use crate::params::{Params as BitcoinParams};
     use crate::{Network as BitcoinNetwork};
-    use float_cmp::approx_eq;
 
 
     #[test]

--- a/bitcoin/src/dogecoin/mod.rs
+++ b/bitcoin/src/dogecoin/mod.rs
@@ -161,7 +161,6 @@ mod tests {
     use crate::block::{ValidationError, Version};
     use crate::consensus::encode::{deserialize, serialize};
     use crate::{CompactTarget, Target, Work};
-    use crate::params::{Params as BitcoinParams};
     use crate::{Network as BitcoinNetwork};
 
 

--- a/bitcoin/src/dogecoin/mod.rs
+++ b/bitcoin/src/dogecoin/mod.rs
@@ -195,9 +195,9 @@ mod tests {
             real_decode.header.validate_pow_with_scrypt(real_decode.header.target()).unwrap(),
             real_decode.block_hash_with_scrypt()
         );
-        // Bitcoin parameters are used because Dogecoin's difficulty calculation is the same as Bitcoin,
-        // which depends on Bitcoin's `max_attainable_target` value
-        assert_eq!(real_decode.header.difficulty(&BitcoinParams::new(BitcoinNetwork::Bitcoin)), 455);
+        // Bitcoin network is used because Dogecoin's difficulty calculation is based on Bitcoin's,
+        // which uses Bitcoin's `max_attainable_target` value
+        assert_eq!(real_decode.header.difficulty(BitcoinNetwork::Bitcoin), 455);
         assert_eq!(real_decode.header.difficulty_float(), 455.52430084170516);
 
         assert_eq!(serialize(&real_decode), some_block);

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -316,6 +316,27 @@ impl Target {
     /// In line with Bitcoin Core this function may return a target value of zero.
     pub fn min_transition_threshold(&self) -> Self { Self(self.0 >> 2) }
 
+    /// Computes the minimum valid [`Target`] threshold allowed for a block in which a difficulty
+    /// adjustment occurs.
+    ///
+    /// The difficulty can only decrease by a factor of 4, 8, or 16 max on each difficulty
+    /// adjustment period, depending on the height.
+    /// 
+    /// ref: <https://github.com/dogecoin/dogecoin/blob/2c513d0172e8bc86fe9a337693b26f2fdf68a013/src/dogecoin.cpp#L57-L66>
+    ///
+    /// # Returns
+    ///
+    /// In line with Dogecoin Core this function may return a target value of zero.
+    pub fn min_transition_threshold_dogecoin(&self, height: u32) -> Self {
+        if height > 10000 {
+            Self(self.0 >> 2)
+        } else if height > 5000 {
+            Self(self.0 >> 3)
+        } else {
+            Self(self.0 >> 4)
+        }
+    }
+
     /// Computes the maximum valid [`Target`] threshold allowed for a block in which a difficulty
     /// adjustment occurs.
     ///
@@ -429,6 +450,44 @@ impl CompactTarget {
         retarget.to_compact_lossy()
     }
 
+    /// Computes the [`CompactTarget`] from a difficulty adjustment in Dogecoin.
+    ///
+    /// ref: <https://github.com/dogecoin/dogecoin/blob/51cbc1fd5d0d045dda2ad84f53572bbf524c6a8e/src/dogecoin.cpp>
+    ///
+    /// Given the previous Target, represented as a [`CompactTarget`], the difficulty is adjusted
+    /// by taking the timespan between them, and multipling the current [`CompactTarget`] by a factor
+    /// of the net timespan and expected timespan. The [`CompactTarget`] may not increase by more than
+    /// a factor of 4, adjust beyond the maximum threshold for the network, or decrease... TODO
+    ///
+    /// # Returns
+    ///
+    /// The expected [`CompactTarget`] recalculation.
+    pub fn from_next_work_required_dogecoin(
+        last: CompactTarget,
+        timespan: u64,
+        params: impl AsRef<Params>
+    ) -> CompactTarget {
+        let params = params.as_ref();
+        if params.no_pow_retargeting { 
+            return last;
+        }
+        // Comments relate to the `pow.cpp` file from Core.
+        // ref: <https://github.com/dogecoin/dogecoin/blob/51cbc1fd5d0d045dda2ad84f53572bbf524c6a8e/src/dogecoin.cpp>
+        let min_timespan = params.pow_target_timespan >> 4; // Lines 64
+        let max_timespan = params.pow_target_timespan << 2; // Lines 65
+        let actual_timespan = timespan.clamp(min_timespan, max_timespan); // Lines 69-72 nModulatedTimespan
+        let prev_target: Target = last.into();
+        let maximum_retarget = prev_target.max_transition_threshold(params); // bnPowLimit
+        let retarget = prev_target.0; // bnNew
+        let retarget = retarget.mul(actual_timespan.into());
+        let retarget = retarget.div(params.pow_target_timespan.into());
+        let retarget = Target(retarget);
+        if retarget.ge(&maximum_retarget) {
+            return maximum_retarget.to_compact_lossy();
+        }
+        retarget.to_compact_lossy()
+    }
+
     /// Computes the [`CompactTarget`] from a difficulty adjustment,
     /// assuming these are the relevant block headers.
     ///
@@ -455,6 +514,40 @@ impl CompactTarget {
         let timespan = current.time - last_epoch_boundary.time;
         let bits = current.bits;
         CompactTarget::from_next_work_required(bits, timespan.into(), params)
+    }
+
+    /// Computes the [`CompactTarget`] from a difficulty adjustment,
+    /// assuming these are the relevant block headers, in the Dogecoin network.
+    ///
+    /// Given two headers, representing the start and end of a difficulty adjustment epoch,
+    /// compute the [`CompactTarget`] based on the net time between them and the current
+    /// [`CompactTarget`].
+    ///
+    /// # Note
+    ///
+    /// See [`CompactTarget::from_next_work_required_dogecoin`].
+    /// 
+    /// Unlike Bitcoin, Dogecoin uses overlapping intervals (see Time Wrap Attack bug fix
+    /// introduced by Litecoin).
+    ///
+    /// For example, to successfully compute the first difficulty adjustments on the Dogecoin network,
+    /// one would pass the following headers:
+    ///     - `current`: Block 239, `last_epoch_boundary`: Block 0
+    ///     - `current`: Block 479, `last_epoch_boundary`: Block 239
+    ///     - `current`: Block 719, `last_epoch_boundary`: Block 479
+    ///     - `current`: Block 959, `last_epoch_boundary`: Block 719
+    ///
+    /// # Returns
+    ///
+    /// The expected [`CompactTarget`] recalculation.
+    pub fn from_header_difficulty_adjustment_dogecoin(
+        last_epoch_boundary: Header,
+        current: Header,
+        params: impl AsRef<Params>,
+    ) -> CompactTarget {
+        let timespan = current.time - last_epoch_boundary.time;
+        let bits = current.bits;
+        CompactTarget::from_next_work_required_dogecoin(bits, timespan.into(), params)
     }
 
     /// Creates a [`CompactTarget`] from a consensus encoded `u32`.


### PR DESCRIPTION
This PR adds methods required for implementing Dogecoin's difficulty adjustment algorithm (DAA). In particular it adds the method `from_next_work_required_dogecoin()` which computes the target value for the next difficulty adjustment period, based on the `timespan` between start and end of period and the `last` target value.

Note: this PR only adds the required logic to compute targets in block period 0-5,000 (see https://github.com/dogecoin/dogecoin/blob/51cbc1fd5d0d045dda2ad84f53572bbf524c6a8e/src/dogecoin.cpp#L41 for complete algorithm). A following PR will add the logic for further periods and in particular for the Digishield algorithm used in later periods.