### PR TITLE
feat(difficulty_calculation): add correct difficulty calculation for pre-digishield blocks (5,001-144,999)

### DIFF
--- a/bitcoin/src/dogecoin/mod.rs
+++ b/bitcoin/src/dogecoin/mod.rs
@@ -354,7 +354,7 @@ mod tests {
         let start_time: u64 = 1386325540; // Genesis block unix time
         let end_time: u64 = 1386475638; // Block 239 unix time
         let timespan = end_time - start_time; // Slower than expected (150,098 seconds diff)
-        let adjustment = CompactTarget::from_next_work_required_dogecoin(starting_bits, timespan, &params);
+        let adjustment = CompactTarget::from_next_work_required_dogecoin(starting_bits, timespan, &params, 240);
         let adjustment_bits = CompactTarget::from_consensus(0x1e0fffff); // Block 240 compact target
         assert_eq!(adjustment, adjustment_bits);
     }
@@ -366,7 +366,7 @@ mod tests {
         let start_time: u64 = 1386475638; // Block 239 unix time
         let end_time: u64 = 1386475840; // Block 479 unix time
         let timespan = end_time - start_time; // Faster than expected (202 seconds diff)
-        let adjustment = CompactTarget::from_next_work_required_dogecoin(starting_bits, timespan, &params);
+        let adjustment = CompactTarget::from_next_work_required_dogecoin(starting_bits, timespan, &params, 480);
         let adjustment_bits = CompactTarget::from_consensus(0x1e00ffff); // Block 480 compact target
         assert_eq!(adjustment, adjustment_bits);
     }
@@ -386,7 +386,7 @@ mod tests {
             bits: epoch_start.bits,
             nonce: epoch_start.nonce
         };
-        let adjustment = CompactTarget::from_header_difficulty_adjustment_dogecoin(epoch_start, current, params);
+        let adjustment = CompactTarget::from_header_difficulty_adjustment_dogecoin(epoch_start, current, params, 240);
         let adjustment_bits = CompactTarget::from_consensus(0x1e0fffff); // Block 240 compact target
         assert_eq!(adjustment, adjustment_bits);
     }
@@ -415,7 +415,7 @@ mod tests {
             bits: starting_bits,
             nonce: 0
         };
-        let adjustment = CompactTarget::from_header_difficulty_adjustment_dogecoin(epoch_start, current, params);
+        let adjustment = CompactTarget::from_header_difficulty_adjustment_dogecoin(epoch_start, current, params, 480);
         let adjustment_bits = CompactTarget::from_consensus(0x1e00ffff); // Block 480 compact target
         assert_eq!(adjustment, adjustment_bits);
     }
@@ -423,25 +423,31 @@ mod tests {
     #[test]
     fn compact_target_from_maximum_upward_difficulty_adjustment() {
         let params = Params::new(Network::Dogecoin);
+        let heights = vec![5000, 10000, 15000];
         let starting_bits = CompactTarget::from_consensus(21403001); // Arbitrary difficulty
         let timespan = (0.06 * params.bitcoin_params.pow_target_timespan as f64) as u64; // > 16x Faster than expected
-        let got = CompactTarget::from_next_work_required_dogecoin(starting_bits, timespan, params);
-        let want = Target::from_compact(starting_bits)
-            .min_transition_threshold_dogecoin(5000)
-            .to_compact_lossy();
-        assert_eq!(got, want);
+        for height in heights {
+            let got = CompactTarget::from_next_work_required_dogecoin(starting_bits, timespan, &params, height);
+            let want = Target::from_compact(starting_bits)
+                .min_transition_threshold_dogecoin(height)
+                .to_compact_lossy();
+            assert_eq!(got, want);
+        }
     }
 
     #[test]
     fn compact_target_from_minimum_downward_difficulty_adjustment() {
         let params = Params::new(Network::Dogecoin);
+        let heights = vec![5000, 10000, 15000];
         let starting_bits = CompactTarget::from_consensus(21403001); // Arbitrary difficulty
         let timespan =  5 * params.bitcoin_params.pow_target_timespan; // > 4x Slower than expected
-        let got = CompactTarget::from_next_work_required_dogecoin(starting_bits, timespan, &params);
-        let want = Target::from_compact(starting_bits)
-            .max_transition_threshold(params)
-            .to_compact_lossy();
-        assert_eq!(got, want);
+        for height in heights {
+            let got = CompactTarget::from_next_work_required_dogecoin(starting_bits, timespan, &params, height);
+            let want = Target::from_compact(starting_bits)
+                .max_transition_threshold(&params)
+                .to_compact_lossy();
+            assert_eq!(got, want);
+        }
     }
 
     #[test]

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -455,9 +455,10 @@ impl CompactTarget {
     /// ref: <https://github.com/dogecoin/dogecoin/blob/51cbc1fd5d0d045dda2ad84f53572bbf524c6a8e/src/dogecoin.cpp>
     ///
     /// Given the previous Target, represented as a [`CompactTarget`], the difficulty is adjusted
-    /// by taking the timespan between them, and multipling the current [`CompactTarget`] by a factor
+    /// by taking the timespan between them, and multiplying the current [`CompactTarget`] by a factor
     /// of the net timespan and expected timespan. The [`CompactTarget`] may not increase by more than
-    /// a factor of 4, adjust beyond the maximum threshold for the network, or decrease... TODO
+    /// a factor of 4, adjust beyond the maximum threshold for the network, or decrease by a factor
+    /// of 16, 8, or 4 depending on block height.
     ///
     /// # Returns
     ///
@@ -465,7 +466,8 @@ impl CompactTarget {
     pub fn from_next_work_required_dogecoin(
         last: CompactTarget,
         timespan: u64,
-        params: impl AsRef<Params>
+        params: impl AsRef<Params>,
+        height: u32
     ) -> CompactTarget {
         let params = params.as_ref();
         if params.no_pow_retargeting { 
@@ -473,8 +475,14 @@ impl CompactTarget {
         }
         // Comments relate to the `pow.cpp` file from Core.
         // ref: <https://github.com/dogecoin/dogecoin/blob/51cbc1fd5d0d045dda2ad84f53572bbf524c6a8e/src/dogecoin.cpp>
-        let min_timespan = params.pow_target_timespan >> 4; // Lines 64
-        let max_timespan = params.pow_target_timespan << 2; // Lines 65
+        let max_timespan = params.pow_target_timespan << 2;
+        let min_timespan = if height > 10000 { // Lines 57-66
+            params.pow_target_timespan >> 2
+        } else if height > 5000 {
+            params.pow_target_timespan >> 3
+        } else {
+            params.pow_target_timespan >> 4
+        };
         let actual_timespan = timespan.clamp(min_timespan, max_timespan); // Lines 69-72 nModulatedTimespan
         let prev_target: Target = last.into();
         let maximum_retarget = prev_target.max_transition_threshold(params); // bnPowLimit
@@ -544,10 +552,11 @@ impl CompactTarget {
         last_epoch_boundary: Header,
         current: Header,
         params: impl AsRef<Params>,
+        height: u32
     ) -> CompactTarget {
         let timespan = current.time - last_epoch_boundary.time;
         let bits = current.bits;
-        CompactTarget::from_next_work_required_dogecoin(bits, timespan.into(), params)
+        CompactTarget::from_next_work_required_dogecoin(bits, timespan.into(), params, height)
     }
 
     /// Creates a [`CompactTarget`] from a consensus encoded `u32`.


### PR DESCRIPTION
[XC-431](https://dfinity.atlassian.net/browse/XC-431?atlOrigin=eyJpIjoiNGZlYzIwYTg0NmE2NGNhOWE2NmUxZTBiNTdjNzE2NGIiLCJwIjoiaiJ9): This PR adds the correct difficulty calculation for pre-digishield blocks (i.e. blocks 5,001-144,999). It follows the previous PR https://github.com/dfinity/rust-dogecoin/pull/8 which added the logic for block period 0-5,000.

The main change is the addition of the correct `min_timespan` for a difficulty adjustment interval allowed for a given block height, as defined by [dogecoin's difficulty adjustment algorithm](https://github.com/dogecoin/dogecoin/blob/51cbc1fd5d0d045dda2ad84f53572bbf524c6a8e/src/dogecoin.cpp#L57). The relevant code can be found here: https://github.com/dfinity/rust-dogecoin/commit/09daa88aba496392b049252ff87ed1cf1545ddb4#diff-874f3e7cfb3e02a8a906534570346fd48a5a58615069afa5a60ceaf4b9542d0eR471-R478

[XC-431]: https://dfinity.atlassian.net/browse/XC-431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ