### PR TITLE
feat: pass p2p protocol version explicitly

### DIFF
--- a/bitcoin/examples/handshake.rs
+++ b/bitcoin/examples/handshake.rs
@@ -99,6 +99,7 @@ fn build_version_message(address: SocketAddr) -> NetworkMessage {
 
     // Construct the message
     NetworkMessage::Version(message_network::VersionMessage::new(
+        p2p::PROTOCOL_VERSION,
         services,
         timestamp as i64,
         addr_recv,

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -594,10 +594,12 @@ mod test {
             NetworkMessage::GetData(vec![Inventory::Transaction(hash([45u8; 32]).into())]),
             NetworkMessage::NotFound(vec![Inventory::Error]),
             NetworkMessage::GetBlocks(GetBlocksMessage::new(
+                crate::p2p::PROTOCOL_VERSION,
                 vec![hash([1u8; 32]).into(), hash([4u8; 32]).into()],
                 hash([5u8; 32]).into(),
             )),
             NetworkMessage::GetHeaders(GetHeadersMessage::new(
+                crate::p2p::PROTOCOL_VERSION,
                 vec![hash([10u8; 32]).into(), hash([40u8; 32]).into()],
                 hash([50u8; 32]).into(),
             )),

--- a/bitcoin/src/p2p/message_blockdata.rs
+++ b/bitcoin/src/p2p/message_blockdata.rs
@@ -13,7 +13,6 @@ use crate::blockdata::block::BlockHash;
 use crate::blockdata::transaction::{Txid, Wtxid};
 use crate::consensus::encode::{self, Decodable, Encodable};
 use crate::internal_macros::impl_consensus_encoding;
-use crate::p2p;
 
 /// An inventory item.
 #[derive(PartialEq, Eq, Clone, Debug, Copy, Hash, PartialOrd, Ord)]
@@ -127,12 +126,8 @@ pub struct GetHeadersMessage {
 
 impl GetBlocksMessage {
     /// Construct a new `getblocks` message
-    pub fn new(locator_hashes: Vec<BlockHash>, stop_hash: BlockHash) -> GetBlocksMessage {
-        GetBlocksMessage { version: p2p::PROTOCOL_VERSION, locator_hashes, stop_hash }
-    }
-    /// Set the version number.
-    pub fn with_version(self, version: u32) -> Self {
-        Self { version, ..self }
+    pub fn new(version: u32, locator_hashes: Vec<BlockHash>, stop_hash: BlockHash) -> GetBlocksMessage {
+        GetBlocksMessage { version, locator_hashes, stop_hash }
     }
 }
 
@@ -140,12 +135,8 @@ impl_consensus_encoding!(GetBlocksMessage, version, locator_hashes, stop_hash);
 
 impl GetHeadersMessage {
     /// Construct a new `getheaders` message
-    pub fn new(locator_hashes: Vec<BlockHash>, stop_hash: BlockHash) -> GetHeadersMessage {
-        GetHeadersMessage { version: p2p::PROTOCOL_VERSION, locator_hashes, stop_hash }
-    }
-    /// Set the version number.
-    pub fn with_version(self, version: u32) -> Self {
-        Self { version, ..self }
+    pub fn new(version: u32, locator_hashes: Vec<BlockHash>, stop_hash: BlockHash) -> GetHeadersMessage {
+        GetHeadersMessage { version, locator_hashes, stop_hash }
     }
 }
 

--- a/bitcoin/src/p2p/message_network.rs
+++ b/bitcoin/src/p2p/message_network.rs
@@ -11,7 +11,6 @@ use io::{Read, Write};
 
 use crate::consensus::{encode, Decodable, Encodable, ReadExt};
 use crate::internal_macros::impl_consensus_encoding;
-use crate::p2p;
 use crate::p2p::address::Address;
 use crate::p2p::ServiceFlags;
 use crate::prelude::*;
@@ -53,6 +52,7 @@ pub struct VersionMessage {
 impl VersionMessage {
     /// Constructs a new `version` message with `relay` set to false
     pub fn new(
+        version: u32,
         services: ServiceFlags,
         timestamp: i64,
         receiver: Address,
@@ -62,7 +62,7 @@ impl VersionMessage {
         start_height: i32,
     ) -> VersionMessage {
         VersionMessage {
-            version: p2p::PROTOCOL_VERSION,
+            version,
             services,
             timestamp,
             receiver,
@@ -72,10 +72,6 @@ impl VersionMessage {
             start_height,
             relay: false,
         }
-    }
-    /// Set the version number.
-    pub fn with_version(self, version: u32) -> Self {
-        Self { version, ..self }
     }
 }
 


### PR DESCRIPTION
Pass protocol version explicitly when constructing network messages.
Remove the previous addition of `with_version` method because it could be confusing when to use it.

This is not a compatible change, but modifications required are fairly minimum.
Hopefully it will not be a problem in the future.