### PR TITLE
refactor(params): simpler and more consistent Dogecoin params

### DIFF
--- a/bitcoin/src/dogecoin/constants.rs
+++ b/bitcoin/src/dogecoin/constants.rs
@@ -81,7 +81,7 @@ pub fn genesis_block(params: impl AsRef<Params>) -> Block {
     let hash: sha256d::Hash = txdata[0].compute_txid().into();
     let merkle_root: TxMerkleNode = hash.into();
 
-    match params.dogecoin_params.network {
+    match params.network {
         Network::Dogecoin => Block {
             header: block::Header {
                 version: block::Version::ONE,

--- a/bitcoin/src/dogecoin/mod.rs
+++ b/bitcoin/src/dogecoin/mod.rs
@@ -177,6 +177,12 @@ impl Network {
     }
 }
 
+impl AsRef<Params> for Network {
+    fn as_ref(&self) -> &Params {
+        self.params()
+    }
+}
+
 impl fmt::Display for Network {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {

--- a/bitcoin/src/dogecoin/mod.rs
+++ b/bitcoin/src/dogecoin/mod.rs
@@ -17,7 +17,6 @@ use crate::dogecoin::params::Params;
 use crate::internal_macros::impl_consensus_encoding;
 use crate::io::{Read, Write};
 use crate::p2p::Magic;
-use crate::params::Params as BitcoinParams;
 use crate::prelude::*;
 use crate::{io, BlockHash, Transaction};
 use core::fmt;
@@ -325,7 +324,7 @@ mod tests {
             assert_eq!(serialize(&header.block_hash_with_scrypt()), test.output);
         }
     }
-    
+
     #[test]
     fn max_target_from_compact() {
         // The highest possible target in Dogecoin is defined as 0x1e0fffff
@@ -336,13 +335,14 @@ mod tests {
     }
 
     #[test]
-    fn compact_target_from_upwards_difficulty_adjustment() {
+    fn compact_target_from_downwards_difficulty_adjustment() {
+        let height = 240;
         let params = Params::new(Network::Dogecoin);
         let starting_bits = CompactTarget::from_consensus(0x1e0ffff0); // Genesis compact target on Mainnet
-        let start_time: u64 = 1386325540; // Genesis block unix time
-        let end_time: u64 = 1386475638; // Block 239 unix time
+        let start_time: i64 = 1386325540; // Genesis block unix time
+        let end_time: i64 = 1386475638; // Block 239 unix time
         let timespan = end_time - start_time; // Slower than expected (150,098 seconds diff)
-        let adjustment = CompactTarget::from_next_work_required_dogecoin(starting_bits, timespan, &params, 240);
+        let adjustment = CompactTarget::from_next_work_required_dogecoin(starting_bits, timespan, &params, height);
         let adjustment_bits = CompactTarget::from_consensus(0x1e0fffff); // Block 240 compact target
         assert_eq!(adjustment, adjustment_bits);
     }
@@ -351,10 +351,10 @@ mod tests {
     fn compact_target_from_downwards_difficulty_adjustment() {
         let params = Params::new(Network::Dogecoin);
         let starting_bits = CompactTarget::from_consensus(0x1e0fffff); // Block 240 compact target
-        let start_time: u64 = 1386475638; // Block 239 unix time
-        let end_time: u64 = 1386475840; // Block 479 unix time
+        let start_time: i64 = 1386475638; // Block 239 unix time
+        let end_time: i64 = 1386475840; // Block 479 unix time
         let timespan = end_time - start_time; // Faster than expected (202 seconds diff)
-        let adjustment = CompactTarget::from_next_work_required_dogecoin(starting_bits, timespan, &params, 480);
+        let adjustment = CompactTarget::from_next_work_required_dogecoin(starting_bits, timespan, &params, height);
         let adjustment_bits = CompactTarget::from_consensus(0x1e00ffff); // Block 480 compact target
         assert_eq!(adjustment, adjustment_bits);
     }
@@ -363,6 +363,8 @@ mod tests {
     fn compact_target_from_downwards_difficulty_adjustment_using_headers() {
         use crate::{block::Version, dogecoin::constants::genesis_block, TxMerkleNode};
         use hashes::Hash;
+
+        let height = 240;
         let params = Params::new(Network::Dogecoin);
         let epoch_start = genesis_block(&params).header;
         // Block 239, the only information used are `bits` and `time`
@@ -374,7 +376,7 @@ mod tests {
             bits: epoch_start.bits,
             nonce: epoch_start.nonce
         };
-        let adjustment = CompactTarget::from_header_difficulty_adjustment_dogecoin(epoch_start, current, params, 240);
+        let adjustment = CompactTarget::from_header_difficulty_adjustment_dogecoin(epoch_start, current, params, height);
         let adjustment_bits = CompactTarget::from_consensus(0x1e0fffff); // Block 240 compact target
         assert_eq!(adjustment, adjustment_bits);
     }
@@ -383,6 +385,8 @@ mod tests {
     fn compact_target_from_upwards_difficulty_adjustment_using_headers() {
         use crate::{block::Version, TxMerkleNode};
         use hashes::Hash;
+
+        let height = 480;
         let params = Params::new(Network::Dogecoin);
         let starting_bits = CompactTarget::from_consensus(0x1e0fffff); // Block 479 compact target
         // Block 239, the only information used is `time`
@@ -403,7 +407,7 @@ mod tests {
             bits: starting_bits,
             nonce: 0
         };
-        let adjustment = CompactTarget::from_header_difficulty_adjustment_dogecoin(epoch_start, current, params, 480);
+        let adjustment = CompactTarget::from_header_difficulty_adjustment_dogecoin(epoch_start, current, params, height);
         let adjustment_bits = CompactTarget::from_consensus(0x1e00ffff); // Block 480 compact target
         assert_eq!(adjustment, adjustment_bits);
     }
@@ -440,10 +444,11 @@ mod tests {
 
     #[test]
     fn compact_target_from_adjustment_is_max_target() {
+        let height = 480;
         let params = Params::new(Network::Dogecoin);
         let starting_bits = CompactTarget::from_consensus(0x1e0fffff); // Block 240 compact target (max target)
-        let timespan =  5 * params.pow_target_timespan; // > 4x Slower than expected
-        let got = CompactTarget::from_next_work_required_dogecoin(starting_bits, timespan, &params, 480);
+        let timespan =  4 * params.pow_target_timespan(height); // 4x Slower than expected
+        let got = CompactTarget::from_next_work_required_dogecoin(starting_bits, timespan, &params, height);
         let want = params.max_attainable_target.to_compact_lossy();
         assert_eq!(got, want);
     }

--- a/bitcoin/src/dogecoin/mod.rs
+++ b/bitcoin/src/dogecoin/mod.rs
@@ -348,7 +348,8 @@ mod tests {
     }
 
     #[test]
-    fn compact_target_from_downwards_difficulty_adjustment() {
+    fn compact_target_from_upwards_difficulty_adjustment() {
+        let height = 480;
         let params = Params::new(Network::Dogecoin);
         let starting_bits = CompactTarget::from_consensus(0x1e0fffff); // Block 240 compact target
         let start_time: i64 = 1386475638; // Block 239 unix time
@@ -417,7 +418,7 @@ mod tests {
         let params = Params::new(Network::Dogecoin);
         let heights = vec![5000, 10000, 15000];
         let starting_bits = CompactTarget::from_consensus(21403001); // Arbitrary difficulty
-        let timespan = (0.06 * params.pow_target_timespan as f64) as u64; // > 16x Faster than expected
+        let timespan = (0.06 * params.pow_target_timespan as f64) as i64; // > 16x Faster than expected
         for height in heights {
             let got = CompactTarget::from_next_work_required_dogecoin(starting_bits, timespan, &params, height);
             let want = Target::from_compact(starting_bits)
@@ -447,7 +448,7 @@ mod tests {
         let height = 480;
         let params = Params::new(Network::Dogecoin);
         let starting_bits = CompactTarget::from_consensus(0x1e0fffff); // Block 240 compact target (max target)
-        let timespan =  4 * params.pow_target_timespan(height); // 4x Slower than expected
+        let timespan =  4 * params.pow_target_timespan; // 4x Slower than expected
         let got = CompactTarget::from_next_work_required_dogecoin(starting_bits, timespan, &params, height);
         let want = params.max_attainable_target.to_compact_lossy();
         assert_eq!(got, want);

--- a/bitcoin/src/dogecoin/mod.rs
+++ b/bitcoin/src/dogecoin/mod.rs
@@ -178,18 +178,6 @@ impl Network {
     }
 }
 
-impl AsRef<BitcoinParams> for Network {
-    fn as_ref(&self) -> &BitcoinParams {
-        &Self::params(*self).bitcoin_params
-    }
-}
-
-impl AsRef<Params> for Network {
-    fn as_ref(&self) -> &Params {
-        self.params()
-    }
-}
-
 impl fmt::Display for Network {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -425,7 +413,7 @@ mod tests {
         let params = Params::new(Network::Dogecoin);
         let heights = vec![5000, 10000, 15000];
         let starting_bits = CompactTarget::from_consensus(21403001); // Arbitrary difficulty
-        let timespan = (0.06 * params.bitcoin_params.pow_target_timespan as f64) as u64; // > 16x Faster than expected
+        let timespan = (0.06 * params.pow_target_timespan as f64) as u64; // > 16x Faster than expected
         for height in heights {
             let got = CompactTarget::from_next_work_required_dogecoin(starting_bits, timespan, &params, height);
             let want = Target::from_compact(starting_bits)
@@ -440,11 +428,11 @@ mod tests {
         let params = Params::new(Network::Dogecoin);
         let heights = vec![5000, 10000, 15000];
         let starting_bits = CompactTarget::from_consensus(21403001); // Arbitrary difficulty
-        let timespan =  5 * params.bitcoin_params.pow_target_timespan; // > 4x Slower than expected
+        let timespan =  5 * params.pow_target_timespan; // > 4x Slower than expected
         for height in heights {
             let got = CompactTarget::from_next_work_required_dogecoin(starting_bits, timespan, &params, height);
             let want = Target::from_compact(starting_bits)
-                .max_transition_threshold(&params)
+                .max_transition_threshold_dogecoin(&params)
                 .to_compact_lossy();
             assert_eq!(got, want);
         }
@@ -454,9 +442,9 @@ mod tests {
     fn compact_target_from_adjustment_is_max_target() {
         let params = Params::new(Network::Dogecoin);
         let starting_bits = CompactTarget::from_consensus(0x1e0fffff); // Block 240 compact target (max target)
-        let timespan =  5 * params.bitcoin_params.pow_target_timespan; // > 4x Slower than expected
-        let got = CompactTarget::from_next_work_required(starting_bits, timespan, &params);
-        let want = params.bitcoin_params.max_attainable_target.to_compact_lossy();
+        let timespan =  5 * params.pow_target_timespan; // > 4x Slower than expected
+        let got = CompactTarget::from_next_work_required_dogecoin(starting_bits, timespan, &params, 480);
+        let want = params.max_attainable_target.to_compact_lossy();
         assert_eq!(got, want);
     }
 

--- a/bitcoin/src/dogecoin/params.rs
+++ b/bitcoin/src/dogecoin/params.rs
@@ -45,7 +45,7 @@ pub struct Params {
     /// Expected amount of time to mine one block.
     pub pow_target_spacing: u64,
     /// Difficulty recalculation interval.
-    pub pow_target_timespan: u64,
+    pub pow_target_timespan: i64,
     /// Determines whether minimal difficulty may be used for blocks or not.
     pub allow_min_difficulty_blocks: bool,
     /// Determines whether retargeting is disabled for this network or not.

--- a/bitcoin/src/dogecoin/params.rs
+++ b/bitcoin/src/dogecoin/params.rs
@@ -7,7 +7,7 @@
 //!
 
 use crate::dogecoin::Network;
-use crate::{CompactTarget, Target};
+use crate::Target;
 
 /// Parameters that influence chain consensus.
 #[non_exhaustive]

--- a/bitcoin/src/dogecoin/params.rs
+++ b/bitcoin/src/dogecoin/params.rs
@@ -33,7 +33,7 @@ pub struct Params {
     /// The maximum **attainable** target value for these params.
     ///
     /// Not all target values are attainable because consensus code uses the compact format to
-    /// represent targets (see [`CompactTarget`]).
+    /// represent targets (see [`crate::CompactTarget`]).
     ///
     /// Note that this value differs from Dogecoin Core's powLimit field in that this value is
     /// attainable, but Dogecoin Core's is not. Specifically, because targets in Bitcoin are always

--- a/bitcoin/src/dogecoin/params.rs
+++ b/bitcoin/src/dogecoin/params.rs
@@ -7,25 +7,49 @@
 //!
 
 use crate::dogecoin::Network;
-use crate::network::Network as BitcoinNetwork;
-use crate::params::Params as BitcoinParams;
-use crate::Target;
+use crate::{CompactTarget, Target};
 
 /// Parameters that influence chain consensus.
-#[derive(Debug, Clone)]
-pub struct Params {
-    /// Parameters inherited from Bitcoin, reused for Dogecoin consensus.
-    pub bitcoin_params: BitcoinParams,
-    /// Parameters that are not inherited from Bitcoin.
-    pub dogecoin_params: DogecoinParams,
-}
-
-/// Dogecoin-specific consensus parameters.
 #[non_exhaustive]
 #[derive(Debug, Clone)]
-pub struct DogecoinParams {
+pub struct Params {
     /// Network for which parameters are valid.
     pub network: Network,
+    /// Time when BIP16 becomes active.
+    pub bip16_time: u32,
+    /// Block height at which BIP34 becomes active.
+    pub bip34_height: u32,
+    /// Block height at which BIP65 becomes active.
+    pub bip65_height: u32,
+    /// Block height at which BIP66 becomes active.
+    pub bip66_height: u32,
+    /// Minimum blocks including miner confirmation.
+    pub rule_change_activation_threshold: u32,
+    /// Number of blocks with the same set of rules.
+    pub miner_confirmation_window: u32,
+    /// Proof of work limit value. It contains the lowest possible difficulty.
+    #[deprecated(since = "0.32.0", note = "field renamed to max_attainable_target")]
+    pub pow_limit: Target,
+    /// The maximum **attainable** target value for these params.
+    ///
+    /// Not all target values are attainable because consensus code uses the compact format to
+    /// represent targets (see [`CompactTarget`]).
+    ///
+    /// Note that this value differs from Dogecoin Core's powLimit field in that this value is
+    /// attainable, but Dogecoin Core's is not. Specifically, because targets in Bitcoin are always
+    /// rounded to the nearest float expressible in "compact form", not all targets are attainable.
+    /// Still, this should not affect consensus as the only place where the non-compact form of
+    /// this is used in Dogecoin Core's consensus algorithm is in comparison and there are no
+    /// compact-expressible values between Dogecoin Core's and the limit expressed here.
+    pub max_attainable_target: Target,
+    /// Expected amount of time to mine one block.
+    pub pow_target_spacing: u64,
+    /// Difficulty recalculation interval.
+    pub pow_target_timespan: u64,
+    /// Determines whether minimal difficulty may be used for blocks or not.
+    pub allow_min_difficulty_blocks: bool,
+    /// Determines whether retargeting is disabled for this network or not.
+    pub no_pow_retargeting: bool,
 }
 
 /// The mainnet parameters.
@@ -47,8 +71,7 @@ impl Params {
 
     /// The mainnet parameters.
     pub const MAINNET: Params = Params {
-        bitcoin_params: BitcoinParams {
-            network: BitcoinNetwork::Bitcoin,
+            network: Network::Dogecoin,
             bip16_time: 1333238400,                 // Apr 1 2012
             bip34_height: 1034383, // 80d1364201e5df97e696c03bdd24dc885e8617b9de51e453c10a4f629b1e797a
             bip65_height: 3464751, // 34cd2cbba4ba366f47e5aa0db5f02c19eba2adf679ceb6653ac003bdc9a0ef1f
@@ -61,14 +84,11 @@ impl Params {
             pow_target_timespan: 4 * 60 * 60, // pre-digishield: 4 hours
             allow_min_difficulty_blocks: false,
             no_pow_retargeting: false,
-        },
-        dogecoin_params: DogecoinParams { network: Network::Dogecoin },
     };
 
     /// The Dogecoin testnet parameters.
     pub const TESTNET: Params = Params {
-        bitcoin_params: BitcoinParams {
-            network: BitcoinNetwork::Testnet,
+            network: Network::Testnet,
             bip16_time: 1333238400,                 // Apr 1 2012
             bip34_height: 708658, // 21b8b97dcdb94caa67c7f8f6dbf22e61e0cfe0e46e1fff3528b22864659e9b38
             bip65_height: 1854705, // 955bd496d23790aba1ecfacb722b089a6ae7ddabaedf7d8fb0878f48308a71f9
@@ -81,14 +101,11 @@ impl Params {
             pow_target_timespan: 4 * 60 * 60, // pre-digishield: 4 hours
             allow_min_difficulty_blocks: true,
             no_pow_retargeting: false,
-        },
-        dogecoin_params: DogecoinParams { network: Network::Testnet },
     };
 
     /// The Dogecoin regtest parameters.
     pub const REGTEST: Params = Params {
-        bitcoin_params: BitcoinParams {
-            network: BitcoinNetwork::Regtest,
+            network: Network::Regtest,
             bip16_time: 1333238400,  // Apr 1 2012
             bip34_height: 100000000, // not activated on regtest
             bip65_height: 1351,
@@ -101,8 +118,6 @@ impl Params {
             pow_target_timespan: 4 * 60 * 60, // pre-digishield: 4 hours
             allow_min_difficulty_blocks: true,
             no_pow_retargeting: true,
-        },
-        dogecoin_params: DogecoinParams { network: Network::Regtest },
     };
 
     /// Creates parameters set for the given network.
@@ -113,10 +128,6 @@ impl Params {
             Network::Regtest => Params::REGTEST,
         }
     }
-}
-
-impl AsRef<BitcoinParams> for Params {
-    fn as_ref(&self) -> &BitcoinParams { &self.bitcoin_params }
 }
 
 impl AsRef<Params> for Params {

--- a/bitcoin/src/dogecoin/params.rs
+++ b/bitcoin/src/dogecoin/params.rs
@@ -43,7 +43,7 @@ pub struct Params {
     /// compact-expressible values between Dogecoin Core's and the limit expressed here.
     pub max_attainable_target: Target,
     /// Expected amount of time to mine one block.
-    pub pow_target_spacing: u64,
+    pub pow_target_spacing: i64,
     /// Difficulty recalculation interval.
     pub pow_target_timespan: i64,
     /// Determines whether minimal difficulty may be used for blocks or not.

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -19,6 +19,7 @@ use crate::block::Header;
 use crate::blockdata::block::BlockHash;
 use crate::consensus::encode::{self, Decodable, Encodable};
 use crate::consensus::Params;
+use crate::dogecoin::params::Params as DogecoinParams;
 use crate::error::{ContainsPrefixError, MissingPrefixError, ParseIntError, PrefixedHexError, UnprefixedHexError};
 
 /// Implement traits and methods shared by `Target` and `Work`.
@@ -306,7 +307,7 @@ impl Target {
     }
 
     /// Computes the minimum valid [`Target`] threshold allowed for a block in which a difficulty
-    /// adjustment occurs.
+    /// adjustment occurs for Bitcoin.
     ///
     /// The difficulty can only decrease or increase by a factor of 4 max on each difficulty
     /// adjustment period.
@@ -317,7 +318,7 @@ impl Target {
     pub fn min_transition_threshold(&self) -> Self { Self(self.0 >> 2) }
 
     /// Computes the minimum valid [`Target`] threshold allowed for a block in which a difficulty
-    /// adjustment occurs.
+    /// adjustment occurs for Dogecoin.
     ///
     /// The difficulty can only decrease by a factor of 4, 8, or 16 max on each difficulty
     /// adjustment period, depending on the height.
@@ -338,7 +339,7 @@ impl Target {
     }
 
     /// Computes the maximum valid [`Target`] threshold allowed for a block in which a difficulty
-    /// adjustment occurs.
+    /// adjustment occurs for Bitcoin.
     ///
     /// The difficulty can only decrease or increase by a factor of 4 max on each difficulty
     /// adjustment period.
@@ -346,6 +347,19 @@ impl Target {
     /// We also check that the calculated target is not greater than the maximum allowed target,
     /// this value is network specific - hence the `params` parameter.
     pub fn max_transition_threshold(&self, params: impl AsRef<Params>) -> Self {
+        let max_attainable = params.as_ref().max_attainable_target;
+        cmp::min(self.max_transition_threshold_unchecked(), max_attainable)
+    }
+
+    /// Computes the maximum valid [`Target`] threshold allowed for a block in which a difficulty
+    /// adjustment occurs for Dogecoin.
+    ///
+    /// The difficulty can only decrease or increase by a factor of 4 max on each difficulty
+    /// adjustment period.
+    ///
+    /// We also check that the calculated target is not greater than the maximum allowed target,
+    /// this value is network specific - hence the `params` parameter.
+    pub fn max_transition_threshold_dogecoin(&self, params: impl AsRef<DogecoinParams>) -> Self {
         let max_attainable = params.as_ref().max_attainable_target;
         cmp::min(self.max_transition_threshold_unchecked(), max_attainable)
     }
@@ -466,7 +480,7 @@ impl CompactTarget {
     pub fn from_next_work_required_dogecoin(
         last: CompactTarget,
         timespan: u64,
-        params: impl AsRef<Params>,
+        params: impl AsRef<DogecoinParams>,
         height: u32
     ) -> CompactTarget {
         let params = params.as_ref();
@@ -485,7 +499,7 @@ impl CompactTarget {
         };
         let actual_timespan = timespan.clamp(min_timespan, max_timespan); // Lines 69-72 nModulatedTimespan
         let prev_target: Target = last.into();
-        let maximum_retarget = prev_target.max_transition_threshold(params); // bnPowLimit
+        let maximum_retarget = prev_target.max_transition_threshold_dogecoin(params); // bnPowLimit
         let retarget = prev_target.0; // bnNew
         let retarget = retarget.mul(actual_timespan.into());
         let retarget = retarget.div(params.pow_target_timespan.into());
@@ -551,7 +565,7 @@ impl CompactTarget {
     pub fn from_header_difficulty_adjustment_dogecoin(
         last_epoch_boundary: Header,
         current: Header,
-        params: impl AsRef<Params>,
+        params: impl AsRef<DogecoinParams>,
         height: u32
     ) -> CompactTarget {
         let timespan = current.time - last_epoch_boundary.time;

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -479,12 +479,12 @@ impl CompactTarget {
     /// The expected [`CompactTarget`] recalculation.
     pub fn from_next_work_required_dogecoin(
         last: CompactTarget,
-        timespan: u64,
+        timespan: i64,
         params: impl AsRef<DogecoinParams>,
         height: u32
     ) -> CompactTarget {
         let params = params.as_ref();
-        if params.no_pow_retargeting { 
+        if params.no_pow_retargeting {
             return last;
         }
         // Comments relate to the `pow.cpp` file from Core.
@@ -501,8 +501,8 @@ impl CompactTarget {
         let prev_target: Target = last.into();
         let maximum_retarget = prev_target.max_transition_threshold_dogecoin(params); // bnPowLimit
         let retarget = prev_target.0; // bnNew
-        let retarget = retarget.mul(actual_timespan.into());
-        let retarget = retarget.div(params.pow_target_timespan.into());
+        let retarget = retarget.mul((modulated_timespan as u64).into()); // Line 80
+        let retarget = retarget.div((retarget_timespan as u64).into()); // Line 81
         let retarget = Target(retarget);
         if retarget.ge(&maximum_retarget) {
             return maximum_retarget.to_compact_lossy();

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -501,8 +501,8 @@ impl CompactTarget {
         let prev_target: Target = last.into();
         let maximum_retarget = prev_target.max_transition_threshold_dogecoin(params); // bnPowLimit
         let retarget = prev_target.0; // bnNew
-        let retarget = retarget.mul((modulated_timespan as u64).into()); // Line 80
-        let retarget = retarget.div((retarget_timespan as u64).into()); // Line 81
+        let retarget = retarget.mul((actual_timespan as u64).into()); // Line 80
+        let retarget = retarget.div((params.pow_target_timespan as u64).into()); // Line 81
         let retarget = Target(retarget);
         if retarget.ge(&maximum_retarget) {
             return maximum_retarget.to_compact_lossy();


### PR DESCRIPTION
Changes to Dogecoin parameters, in preparation for DigiShield difficulty adjustment PR https://github.com/dfinity/rust-dogecoin/pull/11:
- replace `struct Params` encapsulating `bitcoin_params` and `dogecoin_params` into unified `Params` structure.
- change `timespan`  and `pow_target_timespan` types from `u64` to `i64`. The motivation is twofold: 1) [Dogecoin core](https://github.com/dogecoin/dogecoin/blob/51cbc1fd5d0d045dda2ad84f53572bbf524c6a8e/src/consensus/params.h#L67) is using `int64_t` type throughout, 2) manipulating negative `timespan` is easier and safer to handle, which is going to be the case when switching to DigiShield where difficulty adjustment interval is only 1 block. 
- change `pow_target_spacing` type from `u64` to `i64` for consistency with Dogecoin.