### PR TITLE
feat: make Header a parameter of NetworkMessage

### DIFF
--- a/bitcoin/examples/handshake.rs
+++ b/bitcoin/examples/handshake.rs
@@ -9,8 +9,8 @@ use bitcoin::consensus::{encode, Decodable};
 use bitcoin::p2p::{self, address, message, message_network};
 use bitcoin::secp256k1::rand::Rng;
 
-type NetworkMessage = message::NetworkMessage<bitcoin::Block>;
-type RawNetworkMessage = message::RawNetworkMessage<bitcoin::Block>;
+type NetworkMessage = message::NetworkMessage<bitcoin::block::Header, bitcoin::Block>;
+type RawNetworkMessage = message::RawNetworkMessage<bitcoin::block::Header, bitcoin::Block>;
 
 fn main() {
     // This example establishes a connection to a Bitcoin node, sends the initial

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -573,6 +573,31 @@ mod test {
     }
 
     #[test]
+    fn dogecoin_ser_der_raw_network_message_test() {
+        type NetworkMessage = super::NetworkMessage<crate::dogecoin::Header, crate::dogecoin::Block>;
+        type RawNetworkMessage = super::RawNetworkMessage<crate::dogecoin::Header, crate::dogecoin::Block>;
+
+        // Dogecoin mainnet block 62959fd2246701d38917fe59920523ad66111b68e360fe3a60ebdca2dd6d4546 (height 1000013)
+        let bytes = hex!("03016200916a0b2966c72c1bb533469388c7e5d771e0d5570e897fe98453baa8226c2d7e9d73ce00d335ed419b390659c89e3af25ab2ffc8db0f1144cbf2ab8867b140e23dbe6d569e42031b0000000001000000010000000000000000000000000000000000000000000000000000000000000000ffffffff3f0359c90d04566dbe3d2cfabe6d6df5cee89f3766065a3f9ddc4ab57a1adf830944af0ef431e9d4f59c2f4e8985e70800000000000000085600096a01000000ffffffff0100f90295000000001976a91457757ed3d226faf12bd43983896ec81e7fca369a88ac0000000010ce3fcdb40c53bb040487a2ff745a7384314d4c24809aba52a35c74a5be4ca5000000000003d7bec81d9cd6968e141a0d0c1645b9dcca96ab9fb57dbc6f63a4ef669a0ad099de79681c0a67d2f2de006742ab85320b9ecc7df8f9979eff946d1f6964d3ab5956b1698e938dbe001e487469ad0c84c1b008757a7a78908378db499a602949bd00000000030000005d24356ff4b4111265187fd2e89dc7e58019221fba2e4ad0ec789ed38bfd9be152ac7cf211bf53770edf319ccc29cf8692076446430a195ed1c55ad458612d1e3dbe6d56f542011b3a4a43490101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff09034d420f04566dbe3dffffffff010010a5d4e80000001976a914d1895519d5281aa005487b1ff07f3307aced8d6e88ac00000000");
+
+        let block: crate::dogecoin::Block = deserialize(&bytes).unwrap();
+        let header: crate::dogecoin::Header = deserialize(&bytes[0..446]).unwrap();
+
+        assert!(header.aux_pow.is_some());
+
+        // Test only Block and Header messages, which are different than Bitcoin.
+        let msgs = vec![
+            NetworkMessage::Block(block),
+            NetworkMessage::Headers(vec![header]),
+        ];
+
+        for msg in msgs {
+            let raw_msg = RawNetworkMessage::new(Magic::from_bytes([57, 0, 0, 0]), msg);
+            assert_eq!(deserialize::<RawNetworkMessage>(&serialize(&raw_msg)).unwrap(), raw_msg);
+        }
+    }
+
+    #[test]
     fn full_round_ser_der_raw_network_message_test() {
         let version_msg: VersionMessage = deserialize(&hex!("721101000100000000000000e6e0845300000000010000000000000000000000000000000000ffff0000000000000100000000000000fd87d87eeb4364f22cf54dca59412db7208d47d920cffce83ee8102f5361746f7368693a302e392e39392f2c9f040001")).unwrap();
         let tx: Transaction = deserialize(&hex!("0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000")).unwrap();

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -11,7 +11,7 @@ use core::{fmt, iter};
 use hashes::{sha256d, Hash};
 use io::{Read, Write};
 
-use crate::blockdata::{block, transaction};
+use crate::blockdata::transaction;
 use crate::consensus::encode::{self, CheckedData, Decodable, Encodable, VarInt};
 use crate::merkle_tree::MerkleBlock;
 use crate::p2p::address::{AddrV2Message, Address};
@@ -150,9 +150,9 @@ impl std::error::Error for CommandStringError {
 
 /// A Network message
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct RawNetworkMessage<Block> {
+pub struct RawNetworkMessage<Header, Block> {
     magic: Magic,
-    payload: NetworkMessage<Block>,
+    payload: NetworkMessage<Header, Block>,
     payload_len: u32,
     checksum: [u8; 4],
 }
@@ -160,7 +160,7 @@ pub struct RawNetworkMessage<Block> {
 /// A Network message payload. Proper documentation is available on at
 /// [Bitcoin Wiki: Protocol Specification](https://en.bitcoin.it/wiki/Protocol_specification)
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub enum NetworkMessage<Block> {
+pub enum NetworkMessage<Header, Block> {
     /// `version`
     Version(message_network::VersionMessage),
     /// `verack`
@@ -184,7 +184,7 @@ pub enum NetworkMessage<Block> {
     /// `block`
     Block(Block),
     /// `headers`
-    Headers(Vec<block::Header>),
+    Headers(Vec<Header>),
     /// `sendheaders`
     SendHeaders,
     /// `getaddr`
@@ -243,7 +243,7 @@ pub enum NetworkMessage<Block> {
     },
 }
 
-impl<Block> NetworkMessage<Block> {
+impl<Header, Block> NetworkMessage<Header, Block> {
     /// Return the message command as a static string reference.
     ///
     /// This returns `"unknown"` for [NetworkMessage::Unknown],
@@ -300,9 +300,9 @@ impl<Block> NetworkMessage<Block> {
     }
 }
 
-impl<Block: Encodable> RawNetworkMessage<Block> {
+impl<Header: Encodable, Block: Encodable> RawNetworkMessage<Header, Block> {
     /// Creates a [RawNetworkMessage]
-    pub fn new(magic: Magic, payload: NetworkMessage<Block>) -> Self {
+    pub fn new(magic: Magic, payload: NetworkMessage<Header, Block>) -> Self {
         let mut engine = sha256d::Hash::engine();
         let payload_len = payload.consensus_encode(&mut engine).expect("engine doesn't error");
         let payload_len = u32::try_from(payload_len).expect("network message use u32 as length");
@@ -312,12 +312,12 @@ impl<Block: Encodable> RawNetworkMessage<Block> {
     }
 
     /// Consumes the [RawNetworkMessage] instance and returns the inner payload.
-    pub fn into_payload(self) -> NetworkMessage<Block> {
+    pub fn into_payload(self) -> NetworkMessage<Header, Block> {
         self.payload
     }
 
     /// The actual message data
-    pub fn payload(&self) -> &NetworkMessage<Block> {
+    pub fn payload(&self) -> &NetworkMessage<Header, Block> {
         &self.payload
     }
 
@@ -335,9 +335,9 @@ impl<Block: Encodable> RawNetworkMessage<Block> {
     pub fn command(&self) -> CommandString { self.payload.command() }
 }
 
-struct HeaderSerializationWrapper<'a>(&'a Vec<block::Header>);
+struct HeaderSerializationWrapper<'a, Header>(&'a Vec<Header>);
 
-impl<'a> Encodable for HeaderSerializationWrapper<'a> {
+impl<'a, Header: Encodable> Encodable for HeaderSerializationWrapper<'a, Header> {
     #[inline]
     fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         let mut len = 0;
@@ -350,7 +350,7 @@ impl<'a> Encodable for HeaderSerializationWrapper<'a> {
     }
 }
 
-impl<Block: Encodable> Encodable for NetworkMessage<Block> {
+impl<Header: Encodable, Block: Encodable> Encodable for NetworkMessage<Header, Block> {
     fn consensus_encode<W: Write + ?Sized>(&self, writer: &mut W) -> Result<usize, io::Error> {
         match self {
             NetworkMessage::Version(ref dat) => dat.consensus_encode(writer),
@@ -395,7 +395,7 @@ impl<Block: Encodable> Encodable for NetworkMessage<Block> {
     }
 }
 
-impl<Block: Encodable> Encodable for RawNetworkMessage<Block> {
+impl<Header: Encodable, Block: Encodable> Encodable for RawNetworkMessage<Header, Block> {
     fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         let mut len = 0;
         len += self.magic.consensus_encode(w)?;
@@ -407,9 +407,9 @@ impl<Block: Encodable> Encodable for RawNetworkMessage<Block> {
     }
 }
 
-struct HeaderDeserializationWrapper(Vec<block::Header>);
+struct HeaderDeserializationWrapper<Header>(Vec<Header>);
 
-impl Decodable for HeaderDeserializationWrapper {
+impl<Header: Decodable> Decodable for HeaderDeserializationWrapper<Header> {
     #[inline]
     fn consensus_decode_from_finite_reader<R: Read + ?Sized>(
         r: &mut R,
@@ -435,7 +435,7 @@ impl Decodable for HeaderDeserializationWrapper {
     }
 }
 
-impl<Block: Decodable> Decodable for RawNetworkMessage<Block> {
+impl<Header: Decodable, Block: Decodable> Decodable for RawNetworkMessage<Header, Block> {
     fn consensus_decode_from_finite_reader<R: Read + ?Sized>(
         r: &mut R,
     ) -> Result<Self, encode::Error> {
@@ -549,9 +549,9 @@ mod test {
     use hex::test_hex_unwrap as hex;
 
     use super::message_network::{Reject, RejectReason, VersionMessage};
-    use super::{block, AddrV2Message, Address, CommandString, Magic, MerkleBlock};
+    use super::{AddrV2Message, Address, CommandString, Magic, MerkleBlock};
     use crate::bip152::BlockTransactionsRequest;
-    use crate::blockdata::block::Block;
+    use crate::blockdata::block;
     use crate::blockdata::script::ScriptBuf;
     use crate::blockdata::transaction::Transaction;
     use crate::consensus::encode::{deserialize, deserialize_partial, serialize};
@@ -563,9 +563,10 @@ mod test {
         CFCheckpt, CFHeaders, CFilter, GetCFCheckpt, GetCFHeaders, GetCFilters,
     };
     use crate::p2p::ServiceFlags;
+    use block::{Block, Header};
 
-    type NetworkMessage = super::NetworkMessage<Block>;
-    type RawNetworkMessage = super::RawNetworkMessage<Block>;
+    type NetworkMessage = super::NetworkMessage<Header, Block>;
+    type RawNetworkMessage = super::RawNetworkMessage<Header, Block>;
 
     fn hash(slice: [u8; 32]) -> Hash {
         Hash::from_slice(&slice).unwrap()

--- a/fuzz/fuzz_targets/bitcoin/deser_net_msg.rs
+++ b/fuzz/fuzz_targets/bitcoin/deser_net_msg.rs
@@ -1,8 +1,10 @@
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {
-    let _: Result<bitcoin::p2p::message::RawNetworkMessage<bitcoin::Block>, _> =
-        bitcoin::consensus::encode::deserialize(data);
+    let _: Result<
+        bitcoin::p2p::message::RawNetworkMessage<bitcoin::block::Header, bitcoin::Block>,
+        _,
+    > = bitcoin::consensus::encode::deserialize(data);
 }
 
 fn main() {


### PR DESCRIPTION
Because Dogecoin's Header type is now different than Bitcoin's, The NetworkMessage type has to take Header as a parameter too.