### PR TITLE
docs: fix docs.rs build

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-dogecoin"
-version = "0.32.5-doge.0"
+version = "0.32.5-doge.1"
 dependencies = [
  "base58ck",
  "base64",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-dogecoin"
-version = "0.32.5-doge.0"
+version = "0.32.5-doge.1"
 dependencies = [
  "base58ck",
  "base64",

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <h1>Rust Dogecoin</h1>
 
-  <img alt="Rust Dogecoin logo by DFINITY Foundation, see license and source files under /logo" src="./logo/rust-btc+doge@4x.png" width="720" />
+  <img alt="Rust Dogecoin logo by DFINITY Foundation, see license and source files under /logo" src="https://raw.githubusercontent.com/dfinity/rust-dogecoin/doge-master/logo/rust-btc+doge@4x.png" width="720" />
 
   <p>Library with support for de/serialization, parsing and executing on data-structures
     and network messages related to Bitcoin and Dogecoin.

--- a/bitcoin/CHANGELOG.md
+++ b/bitcoin/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 0.32.5-doge.1 - 2025-11-10
+
+- Fix build doc on [docs.rs](https://docs.rs/crate/bitcoin-dogecoin/latest)
+- Add rust-dogecoin logo on githubusercontent
+
 # 0.32.5-doge.0 - 2025-11-03
 
 Initial release of the rust-dogecoin crate, a fork of rust-bitcoin adapted for Dogecoin.

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-dogecoin"
-version = "0.32.5-doge.0"
+version = "0.32.5-doge.1"
 license = "Apache-2.0 OR CC0-1.0"
 repository = "https://github.com/dfinity/rust-dogecoin"
 description = "General purpose library for using and interoperating with Bitcoin and Dogecoin."

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -31,7 +31,7 @@
 
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 // Experimental features we need.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_notable_trait))]
 #![cfg_attr(bench, feature(test))]
 // Coding conventions.
 #![warn(missing_docs)]


### PR DESCRIPTION
Following upstream commit https://github.com/rust-bitcoin/rust-bitcoin/commit/3f3324058941f18032ab9cc5c89815fff21474fd, the `doc_auto_cfg` feature is removed to fix the docs.rs build. Additionally, we enable the `doc_notable_trait` feature flag, following upstream commit https://github.com/rust-bitcoin/rust-bitcoin/commit/dfb76c1e15933fe0058c1bb69c4b1b9acddceee8