### PR TITLE
ci: add publish.yml for trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: Publish bitcoin-dogecoin crate to crates.io
+
+on:
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: "Run cargo publish with --dry-run"
+        required: false
+        type: boolean
+
+jobs:
+  publish-bitcoin-dogecoin:
+    name: Publish bitcoin-dogecoin
+    runs-on: ubuntu-latest
+
+    environment: release
+
+    permissions:
+      id-token: write # Required for OIDC token exchange
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - run: echo "Preparing to cargo publish ${{ github.ref_name }}."
+
+      - name: Publish bitcoin-dogecoin to crates.io
+        run: |
+          if [ "${{ inputs.dryRun }}" = "true" ]; then
+            cargo publish -p bitcoin-dogecoin --dry-run
+          else
+            cargo publish -p bitcoin-dogecoin
+          fi
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
This PR adds the file `publish.yml` which contains trusted publishing workflow for the bitcoin-dogecoin crate.